### PR TITLE
FIX: Items for Cooking

### DIFF
--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -39,9 +39,11 @@ items_table: List[ItemData] = [
     { "name": "Idea: Chicken", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Club", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Coin Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
+    { "name": "Idea: Cooked Meat", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Crane", "classification": ItemClassification.useful, "count": 1 }, # Useful for automation
     { "name": "Idea: Dustbin", "classification": ItemClassification.filler, "count": 1 }, 
     { "name": "Idea: Farm", "classification": ItemClassification.progression, "count": 1 },
+    { "name": "Idea: Frittata", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Fruit Salad", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
     { "name": "Idea: Garden", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Growth", "classification": ItemClassification.progression, "count": 1 },
@@ -60,6 +62,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: Magic Wand", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Market", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Milkshake", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
+    { "name": "Idea: Omelette", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Offspring", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Pickaxe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
     { "name": "Idea: Plank", "classification": ItemClassification.progression, "count": 1 },

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -179,10 +179,14 @@ def set_all_rules(world: MultiWorld, player: int):
                            and state.stacklands_can_make_campfire(player))
     
     set_rule(world.get_location("Cook an Omelette", player),
-             lambda state: state.has("Curious Cuisine Booster Pack", player) and state.stacklands_can_make_campfire(player))
+             lambda state: state.has("Idea: Omelette", player)
+                           and state.has_any(set(["Reap & Sow Booster Pack", "Curious Cuisine Booster Pack"]), player) # Can get eggs from either pack
+                           and state.stacklands_can_make_campfire(player))
     
-    set_rule(world.get_location("Cook an Omelette", player),
-             lambda state: state.has("Curious Cuisine Booster Pack", player) and state.stacklands_can_make_campfire(player))
+    set_rule(world.get_location("Cook a Frittata", player),
+             lambda state: state.has("Idea: Frittata", player)
+                           and state.has("Curious Cuisine Booster Pack", player) # Can get potatoes and eggs from Curious Cuisine
+                           and state.stacklands_can_make_campfire(player))
     
     # 'Discovery' Category
     set_rule(world.get_location("Explore a Forest", player),
@@ -198,8 +202,8 @@ def set_all_rules(world: MultiWorld, player: int):
              lambda state: state.has("Explorers Booster Pack", player))
              
     set_rule(world.get_location("Get a Dog", player),
-             lambda state: (state.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player))
-                            and state.stacklands_access_to_basic_pack(player)) # <- To help prevent above packs spawning before Humble Beginnings, otherwise game is locked)
+             lambda state: (state.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player)
+                            and state.stacklands_access_to_basic_pack(player))) # <- To help prevent above packs spawning before Humble Beginnings, otherwise game is locked)
              
     set_rule(world.get_location("Train an Explorer", player),
              lambda state: (state.has("Explorers Booster Pack", player))


### PR DESCRIPTION
## Changes
- `Idea: Cooked Meat`, `Idea: Frittata` and `Idea: Omeletee` now included as progression items.
- Rulesets included for all three items.