### PR TITLE
Rules Re-Work

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -1,0 +1,461 @@
+import sys
+import os
+
+ap_path = os.path.abspath(os.path.dirname(sys.argv[0]))
+sys.path.insert(0, ap_path)
+
+from worlds import AutoWorldRegister
+from Options import (
+    get_option_groups,
+    Choice,
+    Toggle,
+    Range,
+    ItemSet,
+    ItemDict,
+    LocationSet,
+    OptionSet,
+    FreeText,
+    PlandoConnections,
+    OptionList,
+    PlandoTexts,
+    OptionDict,
+    OptionError,
+)
+from Utils import __version__, local_path
+import Utils
+
+from Generate import main as GenMain
+from Main import main as ERmain
+from argparse import Namespace, ArgumentParser
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+import ctypes
+import threading
+from contextlib import redirect_stderr, redirect_stdout
+from enum import Enum
+from functools import wraps
+from io import StringIO
+from multiprocessing import Pool
+
+import functools
+import logging
+import multiprocessing
+import random
+import shutil
+import string
+import tempfile
+import time
+import traceback
+import yaml
+
+
+OUT_DIR = f"fuzz_output"
+ORIG_USER_PATH = Utils.user_path
+
+
+def exception_in_causes(e, ty):
+    if isinstance(e, ty):
+        return True
+    if e.__cause__ is not None:
+        return exception_in_causes(e.__cause__, ty)
+    return False
+
+
+executor = ThreadPoolExecutor(max_workers=1)
+def run_with_timeout(func, seconds, *args, **kwargs):
+    global executor
+    future = executor.submit(func, *args, **kwargs)
+    try:
+        return future.result(timeout=seconds)
+    except TimeoutError:
+        for thread in threading.enumerate():
+            if thread.name != "MainThread":
+                ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread.ident), ctypes.py_object(TimeoutError))
+
+        executor.shutdown(wait=True, cancel_futures=True)
+        executor = ThreadPoolExecutor(max_workers=1)
+        raise TimeoutError(
+            f"Function '{func.__name__}' timed out after {seconds} seconds"
+        )
+
+
+def world_from_apworld_name(apworld_name):
+    for name, world in AutoWorldRegister.world_types.items():
+        if world.__module__.startswith(f"worlds.{apworld_name}"):
+            return name, world
+
+    raise Exception(f"Couldn't find loaded workd with world: {apworld_name}")
+
+
+# See https://github.com/yaml/pyyaml/issues/103
+yaml.SafeDumper.ignore_aliases = lambda *args: True
+
+# Adapted from archipelago'd generate_yaml_templates
+# https://github.com/ArchipelagoMW/Archipelago/blob/f75a1ae1174fb467e5c5bd5568d7de3c806d5b1c/Options.py#L1504
+def generate_random_yaml(world_name, meta):
+    def dictify_range(option):
+        data = {option.default: 50}
+        for sub_option in ["random", "random-low", "random-high"]:
+            if sub_option != option.default:
+                data[sub_option] = 0
+
+        notes = {}
+        for name, number in getattr(option, "special_range_names", {}).items():
+            notes[name] = f"equivalent to {number}"
+            if number in data:
+                data[name] = data[number]
+                del data[number]
+            else:
+                data[name] = 0
+
+        return data, notes
+
+    def sanitize(value):
+        if isinstance(value, frozenset):
+            return list(value)
+        return value
+
+    game_name, world = world_from_apworld_name(world_name)
+    if world is None:
+        raise Exception(f"Failed to resolve apworld from apworld name: {apworld_name}")
+
+    game_options = {}
+    option_groups = get_option_groups(world)
+    for group, options in option_groups.items():
+        for option_name, option_value in options.items():
+            override = meta.get(None, {}).get(option_name)
+            if not override:
+                override = meta.get(game_name, {}).get(option_name)
+
+            if override is not None:
+                game_options[option_name] = override
+                continue
+
+            game_options[option_name] = sanitize(
+                get_random_value(option_name, option_value)
+            )
+
+    yaml_content = {
+        "description": "%s Template, generated with https://github.com/Eijebong/Archipelago-fuzzer"
+        % game_name,
+        "game": game_name,
+        "requires": {
+            "version": __version__,
+        },
+        game_name: game_options,
+    }
+
+    res = yaml.safe_dump(yaml_content, sort_keys=False)
+
+    return res
+
+
+def get_random_value(name, option):
+    if name == "item_links":
+        # Let's not fuck with item links right now, I'm scared
+        return option.default
+
+    if name == "megamix_mod_data":
+        # Megamix is a special child and requires this to be valid JSON. Since we can't provide that, just ignore it
+        return option.default
+
+    if issubclass(option, (PlandoConnections, PlandoTexts)):
+        # See, I was already afraid with item_links but now it's plain terror. Let's not ever touch this ever.
+        return option.default
+
+    if name == "gfxmod":
+        # XXX: LADX has this and it should be a choice but is freetext for some reason...
+        # Putting invalid values here means the gen fails even though it doesn't affect any logic
+        # Just return Link for now.
+        return "Link"
+
+    if issubclass(option, OptionDict):
+        # This is for example factorio's start_items and worldgen settings. I don't think it's worth randomizing those as I'm not expecting the generation outcome to change from them.
+        # Plus I have no idea how to randomize them in the first place :)
+        return option.default
+
+    if issubclass(option, (Choice, Toggle)):
+        return random.choice(list(option.options.keys()))
+
+    if issubclass(option, Range):
+        return random.randint(option.range_start, option.range_end)
+
+    if issubclass(option, (ItemSet, ItemDict, LocationSet)):
+        # I don't know what to do here so just return the default value instead of a random one.
+        # This affects options like start inventory, local items, non local
+        # items so it's not the end of the world if they don't get randomized
+        # but we might want to look into that later on
+        return option.default
+
+    if issubclass(option, OptionSet):
+        return random.sample(
+            list(option.valid_keys), k=random.randint(0, len(option.valid_keys))
+        )
+
+    if issubclass(option, OptionList):
+        return random.sample(
+            list(option.valid_keys), k=random.randint(0, len(option.valid_keys))
+        )
+
+    if issubclass(option, FreeText):
+        return "".join(
+            random.choice(string.ascii_letters) for i in range(random.randint(0, 255))
+        )
+
+    return option.default
+
+
+def call_generate(yaml_path, output_path):
+    from settings import get_settings
+
+    settings = get_settings()
+
+    args = Namespace(
+        **{
+            "weights_file_path": settings.generator.weights_file_path,
+            "sameoptions": False,
+            "player_files_path": yaml_path,
+            "seed": random.randint(0, 1000000000),
+            "multi": 1,
+            "spoiler": 1,
+            "outputpath": output_path,
+            "race": False,
+            "meta_file_path": "meta-doesnt-exist.yaml",
+            "log_level": "info",
+            "yaml_output": 1,
+            "plando": [],
+            "skip_prog_balancing": False,
+            "skip_output": False,
+            "csv_output": False,
+            "log_time": False,
+        }
+    )
+    erargs, seed = GenMain(args)
+    ERmain(erargs, seed)
+
+
+def gen_wrapper(yaml_contents, apworld_name, timeout_s, i, dump_option_errors):
+    out_buf = StringIO()
+
+    try:
+        # We don't care about the actual gen output, just trash it immediately after gen
+        output_path = tempfile.mkdtemp(prefix="apfuzz")
+
+        # Override Utils.user path so we can customize the logs folder
+        # This is very important because every gen starts a thread that cleans all logs older than 7 days.
+        # This is not customizable in any way shape or form. By throwing logs files away, we prevent that thread
+        # from becoming more and more busy as gens go.
+        def my_user_path(name):
+            if name == "logs":
+                return output_path
+            return ORIG_USER_PATH(name)
+
+        Utils.user_path = my_user_path
+
+        yaml_path_dir = tempfile.mkdtemp(prefix="apfuzz")
+        for nb, yaml_content in enumerate(yaml_contents):
+            yaml_path = os.path.join(yaml_path_dir, f"{i}-{nb}.yaml")
+            open(yaml_path, "wb").write(yaml_content.encode("utf-8"))
+
+        with redirect_stdout(out_buf), redirect_stderr(out_buf):
+            run_with_timeout(call_generate, timeout_s, yaml_path_dir, output_path)
+        return GenOutcome.Success
+    except Exception as e:
+        is_timeout = isinstance(e, TimeoutError)
+        is_option_error = exception_in_causes(e, OptionError)
+
+        if is_option_error and not dump_option_errors:
+            return GenOutcome.OptionError
+
+        if is_option_error:
+            error_ty = "ignored"
+        elif is_timeout:
+            error_ty = "timeout"
+        else:
+            error_ty = "error"
+
+        error_output_dir = os.path.join(OUT_DIR, error_ty, apworld_name, str(i))
+        os.makedirs(error_output_dir)
+
+        for nb, yaml_content in enumerate(yaml_contents):
+            error_yaml_path = os.path.join(error_output_dir, f"{i}-{nb}.yaml")
+            open(error_yaml_path, "wb").write(yaml_content.encode("utf-8"))
+
+        error_log_path = os.path.join(error_output_dir, f"{i}.log")
+        with open(error_log_path, "w") as fd:
+            fd.write(out_buf.getvalue())
+
+            if is_timeout:
+                fd.write(f"[...] Generation killed here after {timeout_s}s")
+                return GenOutcome.Timeout
+            else:
+                fd.write("".join(traceback.format_exception(e)))
+
+        return GenOutcome.OptionError if is_option_error else GenOutcome.Failure
+    finally:
+        root_logger = logging.getLogger()
+        handlers = root_logger.handlers[:]
+        for handler in handlers:
+            root_logger.removeHandler(handler)
+            handler.close()
+
+        shutil.rmtree(output_path)
+        shutil.rmtree(yaml_path_dir)
+
+
+class GenOutcome(Enum):
+    Success = 0
+    Failure = 1
+    Timeout = 2
+    OptionError = 3
+
+
+SUCCESS = 0
+FAILURE = 0
+TIMEOUTS = 0
+OPTION_ERRORS = 0
+SUBMITTED = 0
+
+
+def success(result):
+    global SUCCESS, FAILURE, SUBMITTED, OPTION_ERRORS, TIMEOUTS
+    if result == GenOutcome.Success:
+        SUCCESS += 1
+        print(".", end="")
+    elif result == GenOutcome.Failure:
+        print("F", end="")
+        FAILURE += 1
+    elif result == GenOutcome.Timeout:
+        print("T", end="")
+        TIMEOUTS += 1
+    elif result == GenOutcome.OptionError:
+        print("I", end="")
+        OPTION_ERRORS += 1
+
+    sys.stdout.flush()
+
+    SUBMITTED -= 1
+
+
+def error(e):
+    import traceback
+
+    traceback.print_exception(e)
+
+
+def print_status():
+    print()
+    print("Success:", SUCCESS)
+    print("Failures:", FAILURE)
+    print("Timeouts:", TIMEOUTS)
+    print("Ignored:", OPTION_ERRORS)
+    print()
+    print("Time taken:{:.2f}s".format(time.time() - START))
+
+
+if __name__ == "__main__":
+
+    def main(p, args):
+        global SUBMITTED
+
+        apworld_name = args.game
+        if args.meta:
+            with open(args.meta, "r") as fd:
+                meta = yaml.safe_load(fd.read())
+        else:
+            meta = {}
+
+        if apworld_name is not None:
+            world = world_from_apworld_name(apworld_name)
+            if world is None:
+                raise Exception(
+                    f"Failed to resolve apworld from apworld name: {apworld_name}"
+                )
+
+        if os.path.exists(OUT_DIR):
+            shutil.rmtree(OUT_DIR)
+        os.makedirs(OUT_DIR)
+
+        sys.stdout.write("\x1b[2J\x1b[H")
+        sys.stdout.flush()
+
+        i = 0
+        valid_worlds = [
+            world.__module__.split(".")[1]
+            for world in AutoWorldRegister.world_types.values()
+        ]
+        if "apsudoku" in valid_worlds:
+            valid_worlds.remove("apsudoku")
+
+        yamls_per_run_bounds = [int(arg) for arg in args.yamls_per_run.split("-")]
+
+        if len(yamls_per_run_bounds) not in {1, 2}:
+            raise Exception(
+                "Invalid value passed for `yamls_per_run`. Either pass an int or a range like `1-10`"
+            )
+
+        if len(yamls_per_run_bounds) == 2:
+            if yamls_per_run_bounds[0] >= yamls_per_run_bounds[1]:
+                raise Exception("Invalid range value passed for `yamls_per_run`.")
+
+        while i < args.runs:
+            if apworld_name is None:
+                actual_apworld = random.choice(valid_worlds)
+            else:
+                actual_apworld = apworld_name
+
+            if len(yamls_per_run_bounds) == 1:
+                yamls_this_run = yamls_per_run_bounds[0]
+            else:
+                # +1 here to make the range inclusive
+                yamls_this_run = random.randrange(
+                    yamls_per_run_bounds[0], yamls_per_run_bounds[1] + 1
+                )
+
+            random_yamls = [
+                generate_random_yaml(actual_apworld, meta) for _ in range(yamls_this_run)
+            ]
+
+            SUBMITTED += 1
+            last_job = p.apply_async(
+                gen_wrapper,
+                args=(random_yamls, actual_apworld, args.timeout, i, args.dump_ignored),
+                callback=success,
+                error_callback=error,
+            )
+
+            while SUBMITTED >= args.jobs * 10:
+                # Poll the last job to keep the queue running
+                last_job.ready()
+                time.sleep(0.001)
+
+            i += 1
+
+        while SUBMITTED > 0:
+            last_job.ready()
+            time.sleep(0.05)
+
+    parser = ArgumentParser(prog="apfuzz")
+    parser.add_argument("-g", "--game", default=None)
+    parser.add_argument("-j", "--jobs", default=10, type=int)
+    parser.add_argument("-r", "--runs", type=int)
+    parser.add_argument("-n", "--yamls_per_run", default="1", type=str)
+    parser.add_argument("-t", "--timeout", default=15, type=int)
+    parser.add_argument("-m", "--meta", default=None, type=None)
+    parser.add_argument("--dump-ignored", default=False, action="store_true")
+
+    args = parser.parse_args()
+
+    try:
+        can_fork = hasattr(os, "fork")
+        # fork here is way faster because it doesn't have to reload all worlds, but it's only available on some platforms
+        # forking for every job also has the advantage of being sure that the process is "clean". Although I don't know if that actually matters
+        start_method = "fork" if can_fork else "spawn"
+        multiprocessing.set_start_method(start_method)
+        with Pool(processes=args.jobs, maxtasksperchild=None) as p:
+            START = time.time()
+            main(p, args)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        print_status()
+        executor.shutdown()

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -37,18 +37,18 @@ items_table: List[ItemData] = [
     { "name": "Idea: Campfire", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Chainmail Armor", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
     { "name": "Idea: Chicken", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Club", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Coin Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
+    { "name": "Idea: Club", "classification": ItemClassification.useful, "count": 1 }, # Useful as additional fighting class
+    { "name": "Idea: Coin Chest", "classification": ItemClassification.progression, "count": 1 }, # Storage is useful
     { "name": "Idea: Cooked Meat", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Crane", "classification": ItemClassification.useful, "count": 1 }, # Useful for automation
+    { "name": "Idea: Crane", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Dustbin", "classification": ItemClassification.filler, "count": 1 }, 
     { "name": "Idea: Farm", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Frittata", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Fruit Salad", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
+    { "name": "Idea: Fruit Salad", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Garden", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Growth", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Hammer", "classification": ItemClassification.useful, "count": 1 }, # Building faster is useful
-    { "name": "Idea: Hotpot", "classification": ItemClassification.useful, "count": 1 }, # Useful for keeping enough food, but not required
+    { "name": "Idea: Hotpot", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
@@ -61,7 +61,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: Magic Tome", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Magic Wand", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Market", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Milkshake", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
+    { "name": "Idea: Milkshake", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Omelette", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Offspring", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Pickaxe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
@@ -71,14 +71,14 @@ items_table: List[ItemData] = [
     { "name": "Idea: Resource Magnet", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Sawmill", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
     { "name": "Idea: Shed", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Slingshot", "classification": ItemClassification.filler, "count": 1 },
+    { "name": "Idea: Slingshot", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Smithy", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Spear", "classification": ItemClassification.progression, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
     { "name": "Idea: Spiked Plank", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Stew", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
+    { "name": "Idea: Stew", "classification": ItemClassification.filler, "count": 1 }, # Food types are useful
     { "name": "Idea: Stick", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Stove", "classification": ItemClassification.useful, "count": 1 }, # Useful for keeping enough food, but not required
+    { "name": "Idea: Stove", "classification": ItemClassification.progression, "count": 1 }, # Useful for keeping enough food, but not required
     { "name": "Idea: Sword", "classification": ItemClassification.useful, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
     { "name": "Idea: Temple", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Throwing Stars", "classification": ItemClassification.progression, "count": 1 },
@@ -97,8 +97,8 @@ items_table: List[ItemData] = [
     # Resources
     { "name": "Berry x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Flint x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 }, # Could add something like a 'Get Pooped' "trap" item that spawns a whole bunch of poop, toggle-able in options
+    { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
+    { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Stone x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Wood x5", "classification": ItemClassification.filler, "count": 1 }
     

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -88,15 +88,16 @@ items_table: List[ItemData] = [
     { "name": "Idea: Wooden Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for 'Combat level 20' but are other things available
     
     # Equipment
-    { "name": "Club", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Magic Wand", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Spear", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Sword", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Wooden Shield", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Club", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Magic Wand", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Spear", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Sword", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Wooden Shield", "classification": ItemClassification.filler, "count": 1 },
     
     # Resources
+    { "name": "Berry x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Flint x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 }, # Could add something like a 'Get Pooped' "trap" item that spawns a whole bunch of poop, toggle-able in options
     { "name": "Stone x5", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Wood x5", "classification": ItemClassification.filler, "count": 1 }
@@ -139,8 +140,8 @@ def create_all_items(world: MultiWorld, player: int, options: StacklandsOptions)
     for item in items_table:
         
         # Exclude Humble Beginnings if 'basic pack' option is true
-        # if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
-        #     continue
+        if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
+            continue
 
         for _ in range(item["count"]):
             world.itempool.append(create_item(player, item))

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -51,7 +51,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: Hotpot", "classification": ItemClassification.useful, "count": 1 }, # Useful for keeping enough food, but not required
     { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Iron Mine", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
+    { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
     { "name": "Idea: Iron Shield", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Lumber Camp", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Magic Blade", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
@@ -69,7 +69,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: Quarry", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Resource Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
     { "name": "Idea: Resource Magnet", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Sawmill", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
+    { "name": "Idea: Sawmill", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
     { "name": "Idea: Shed", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Slingshot", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
@@ -138,9 +138,9 @@ def create_item(player: int, item: ItemData) -> StacklandsItem:
 def create_all_items(world: MultiWorld, player: int, options: StacklandsOptions):
     for item in items_table:
         
-        # Exclude Hunble Beginnings if 'basic pack' option is true
-        if options.basic_pack and item["name"] == "Humble Beginnings Booster Pack":
-            continue
+        # Exclude Humble Beginnings if 'basic pack' option is true
+        # if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
+        #     continue
 
         for _ in range(item["count"]):
             world.itempool.append(create_item(player, item))

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -52,7 +52,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
-    { "name": "Idea: Iron Shield", "classification": ItemClassification.filler, "count": 1 },
+    { "name": "Idea: Iron Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
     { "name": "Idea: Lumber Camp", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Magic Blade", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
     { "name": "Idea: Magic Glue", "classification": ItemClassification.filler, "count": 1 },
@@ -74,7 +74,7 @@ items_table: List[ItemData] = [
     { "name": "Idea: Slingshot", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
     { "name": "Idea: Smithy", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Spear", "classification": ItemClassification.useful, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
+    { "name": "Idea: Spear", "classification": ItemClassification.progression, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
     { "name": "Idea: Spiked Plank", "classification": ItemClassification.filler, "count": 1 },
     { "name": "Idea: Stew", "classification": ItemClassification.useful, "count": 1 }, # Food types are useful
     { "name": "Idea: Stick", "classification": ItemClassification.progression, "count": 1 },

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -1,147 +1,199 @@
+import logging
+from typing import Dict, Optional, NamedTuple
 from BaseClasses import Item, ItemClassification, MultiWorld
-from .Options import StacklandsOptions
-from typing import Dict, List, Set, TypedDict
 
 class StacklandsItem(Item):
     game = "Stacklands"
+
+    def __init__(self, name, player: int = None):
+        item_data = item_table[name]
+        super(StacklandsItem, self).__init__(
+            name,
+            item_data.classification,
+            item_data.code,
+            player
+        )
     
 
-class ItemData(TypedDict):
-    name: str
-    classification: ItemClassification
-    count: int
+class ItemData(NamedTuple):
+    code: Optional[int]
+    classification: ItemClassification = ItemClassification.filler
+    event: bool = False
 
-items_table: List[ItemData] = [
-    
+item_table: Dict[str, ItemData] = {
+    "Idea: Stick":          ItemData(90001, ItemClassification.progression  ),
+    "Idea: Campfire":       ItemData(90002, ItemClassification.progression  ),
+    "Idea: Plank":          ItemData(90003, ItemClassification.progression  ),
+    "Idea: Sawmill":        ItemData(90004, ItemClassification.progression  ),
+    "Idea: Iron Bar":       ItemData(90005, ItemClassification.progression  ),
+    "Idea: Brick":          ItemData(90006, ItemClassification.progression  ),
+    "Idea: Smelter":        ItemData(90007, ItemClassification.progression  ),
+    "Filler Item 1":        ItemData(90008, ItemClassification.filler       ),
+    "Filler Item 2":        ItemData(90009, ItemClassification.filler       ),
+    "Filler Item 3":        ItemData(90010, ItemClassification.filler       ),
+    "Filler Item 4":        ItemData(90010, ItemClassification.filler       ),
+    "Filler Item 5":        ItemData(90011, ItemClassification.filler       ),
+
+    # Events
+    "Campfire": ItemData(None, ItemClassification.progression, True),
+    "Sawmill":  ItemData(None, ItemClassification.progression, True),
+    "Smelter":  ItemData(None, ItemClassification.progression, True),
+    "Victory":  ItemData(None, ItemClassification.progression, True),
+}
+
+event_table: Dict[str, str] = {
+    "Ability to Build Campfire":    "Campfire",
+    "Ability to Build Sawmill":     "Sawmill",
+    "Ability to Build Smelter":     "Smelter",
+    "Defeat Boss":                  "Victory",
+}
+
+# Create all items
+def create_all_items(world: MultiWorld, player: int) -> None:
+    pool = []
+    for name, item in item_table.items():
+        if item.event == False:
+            item = StacklandsItem(name, player)
+            pool.append(item)
+
+    # Add items to the pool
+    world.itempool += pool
+
+    ## Add event items
+    for event, item in event_table.items():
+        event_item = StacklandsItem(item, player)
+        world.get_location(event, player).place_locked_item(event_item)
+
+    # [
     ### Mainland Items ###
 
-    # Booster Packs
-    { "name": "Humble Beginnings Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Seeking Wisdom Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Reap & Sow Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Curious Cuisine Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Logic and Reason Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "The Armory Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Explorers Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Order and Structure Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # # Booster Packs
+    # { "name": "Humble Beginnings Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Seeking Wisdom Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Reap & Sow Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Curious Cuisine Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Logic and Reason Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "The Armory Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Explorers Booster Pack", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Order and Structure Booster Pack", "classification": ItemClassification.progression, "count": 1 },
     
-    # Ideas
-    { "name": "Idea: Animal Pen", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Axe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
-    { "name": "Idea: Bone Spear", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    { "name": "Idea: Boomerang", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    { "name": "Idea: Breeding Pen", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Brick", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Brickyard", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Butchery", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Campfire", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Chainmail Armor", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    { "name": "Idea: Chicken", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Club", "classification": ItemClassification.useful, "count": 1 }, # Useful as additional fighting class
-    { "name": "Idea: Coin Chest", "classification": ItemClassification.progression, "count": 1 }, # Storage is useful
-    { "name": "Idea: Cooked Meat", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Crane", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Dustbin", "classification": ItemClassification.filler, "count": 1 }, 
-    { "name": "Idea: Farm", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Frittata", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Fruit Salad", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Garden", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Growth", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Hammer", "classification": ItemClassification.useful, "count": 1 }, # Building faster is useful
-    { "name": "Idea: Hotpot", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
-    { "name": "Idea: Iron Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    { "name": "Idea: Lumber Camp", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Magic Blade", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    { "name": "Idea: Magic Glue", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Magic Ring", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Magic Staff", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon / 'Train a Wizard' quest, but can create Magic Wand instead
-    { "name": "Idea: Magic Tome", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Magic Wand", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Market", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Milkshake", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Omelette", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Offspring", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Pickaxe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
-    { "name": "Idea: Plank", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Quarry", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Resource Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
-    { "name": "Idea: Resource Magnet", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Sawmill", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
-    { "name": "Idea: Shed", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Slingshot", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Smithy", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Spear", "classification": ItemClassification.progression, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
-    { "name": "Idea: Spiked Plank", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Stew", "classification": ItemClassification.filler, "count": 1 }, # Food types are useful
-    { "name": "Idea: Stick", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Stove", "classification": ItemClassification.progression, "count": 1 }, # Useful for keeping enough food, but not required
-    { "name": "Idea: Sword", "classification": ItemClassification.useful, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
-    { "name": "Idea: Temple", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: Throwing Stars", "classification": ItemClassification.progression, "count": 1 },
-    { "name": "Idea: University", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Warehouse", "classification": ItemClassification.useful, "count": 1 }, # Higher card limit is useful
-    { "name": "Idea: Wizard Robe", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Idea: Wooden Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for 'Combat level 20' but are other things available
+    # # Ideas
+    # { "name": "Idea: Animal Pen", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Axe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
+    # { "name": "Idea: Bone Spear", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
+    # { "name": "Idea: Boomerang", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
+    # { "name": "Idea: Breeding Pen", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Brick", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Brickyard", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Butchery", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Campfire", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Chainmail Armor", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
+    # { "name": "Idea: Chicken", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Club", "classification": ItemClassification.useful, "count": 1 }, # Useful as additional fighting class
+    # { "name": "Idea: Coin Chest", "classification": ItemClassification.progression, "count": 1 }, # Storage is useful
+    # { "name": "Idea: Cooked Meat", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Crane", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Dustbin", "classification": ItemClassification.filler, "count": 1 }, 
+    # { "name": "Idea: Farm", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Frittata", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Fruit Salad", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Garden", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Growth", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Hammer", "classification": ItemClassification.useful, "count": 1 }, # Building faster is useful
+    # { "name": "Idea: Hotpot", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
+    # { "name": "Idea: Iron Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
+    # { "name": "Idea: Lumber Camp", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Magic Blade", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
+    # { "name": "Idea: Magic Glue", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Magic Ring", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Magic Staff", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon / 'Train a Wizard' quest, but can create Magic Wand instead
+    # { "name": "Idea: Magic Tome", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Magic Wand", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Market", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Milkshake", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Omelette", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Offspring", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Pickaxe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
+    # { "name": "Idea: Plank", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Quarry", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Resource Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
+    # { "name": "Idea: Resource Magnet", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Sawmill", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
+    # { "name": "Idea: Shed", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Slingshot", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Smithy", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Spear", "classification": ItemClassification.progression, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
+    # { "name": "Idea: Spiked Plank", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Stew", "classification": ItemClassification.filler, "count": 1 }, # Food types are useful
+    # { "name": "Idea: Stick", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Stove", "classification": ItemClassification.progression, "count": 1 }, # Useful for keeping enough food, but not required
+    # { "name": "Idea: Sword", "classification": ItemClassification.useful, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
+    # { "name": "Idea: Temple", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: Throwing Stars", "classification": ItemClassification.progression, "count": 1 },
+    # { "name": "Idea: University", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Warehouse", "classification": ItemClassification.useful, "count": 1 }, # Higher card limit is useful
+    # { "name": "Idea: Wizard Robe", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Idea: Wooden Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for 'Combat level 20' but are other things available
     
-    # Equipment
-    # { "name": "Club", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Magic Wand", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Spear", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Sword", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Wooden Shield", "classification": ItemClassification.filler, "count": 1 },
+    # # Equipment
+    # # { "name": "Club", "classification": ItemClassification.filler, "count": 1 },
+    # # { "name": "Magic Wand", "classification": ItemClassification.filler, "count": 1 },
+    # # { "name": "Spear", "classification": ItemClassification.filler, "count": 1 },
+    # # { "name": "Sword", "classification": ItemClassification.filler, "count": 1 },
+    # # { "name": "Wooden Shield", "classification": ItemClassification.filler, "count": 1 },
     
-    # Resources
-    { "name": "Berry x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Flint x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Stone x5", "classification": ItemClassification.filler, "count": 1 },
-    { "name": "Wood x5", "classification": ItemClassification.filler, "count": 1 }
+    # # Resources
+    # { "name": "Berry x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Flint x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Stone x5", "classification": ItemClassification.filler, "count": 1 },
+    # { "name": "Wood x5", "classification": ItemClassification.filler, "count": 1 }
     
     # Traps (to be implemented..)
     # - Spawn enemies onto the board?
     # - 'Get Pooped' item that spawns a bunch of poop?
-]
+# ]
 
-item_group_table: Dict[str, Set[str]] = {
-    "All Ideas": set(item["name"] for item in items_table if item["name"].startswith("Idea:")),
-    "All Booster Packs": set(item["name"] for item in items_table if item["name"].endswith("Booster Pack")),
-    "Basic Booster Packs": {"Humble Beginnings Booster Pack", "Seeking Wisdom Booster Pack", "Reap & Sow Booster Pack"}
-}
+# item_group_table: Dict[str, Set[str]] = {
+#     "All Ideas": set(item["name"] for item in items_table if item["name"].startswith("Idea:")),
+#     "All Booster Packs": set(item["name"] for item in items_table if item["name"].endswith("Booster Pack")),
+#     "Basic Booster Packs": {"Humble Beginnings Booster Pack", "Seeking Wisdom Booster Pack", "Reap & Sow Booster Pack"}
+# }
     
-# ID assignment
-base_id: int = 92000
-current_id: int = base_id
+# # ID assignment
+# base_id: int = 92000
+# current_id: int = base_id
 
-# Lookups
-lookup_id_to_name = {}
-lookup_name_to_id = {}   
+# # Lookups
+# lookup_id_to_name = {}
+# lookup_name_to_id = {}   
 
-# Create item lookups
-for item in items_table:
+# # Create item lookups
+# for item in items_table:
     
-    # Add to lookups
-    lookup_id_to_name[current_id] = item["name"]
-    lookup_name_to_id[item["name"]] = current_id
+#     # Add to lookups
+#     lookup_id_to_name[current_id] = item["name"]
+#     lookup_name_to_id[item["name"]] = current_id
     
-    # Increment ID
-    current_id += 1
+#     # Increment ID
+#     current_id += 1
 
 # Create an item as a StacklandsItem object
-def create_item(player: int, item: ItemData) -> StacklandsItem:
-    return StacklandsItem(item["name"], item["classification"], lookup_name_to_id[item["name"]], player=player)
+# def create_item(player: int, item: ItemData) -> StacklandsItem:
+#     return StacklandsItem(item["name"], item["classification"], lookup_name_to_id[item["name"]], player=player)
 
-# Add all items to the item pool
-def create_all_items(world: MultiWorld, player: int, options: StacklandsOptions):
-    for item in items_table:
+# # Add all items to the item pool
+# def create_all_items(world: MultiWorld, player: int, options: StacklandsOptions):
+#     for item in items_table:
         
-        # Exclude Humble Beginnings if 'basic pack' option is true
-        if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
-            continue
+#         # Exclude Humble Beginnings if 'basic pack' option is true
+#         if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
+#             continue
 
-        for _ in range(item["count"]):
-            world.itempool.append(create_item(player, item))
+#         for _ in range(item["count"]):
+#             world.itempool.append(create_item(player, item))

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -1,199 +1,154 @@
 import logging
-from typing import Dict, Optional, NamedTuple
+from typing import Dict, List, NamedTuple
 from BaseClasses import Item, ItemClassification, MultiWorld
+
+class ItemData(NamedTuple):
+    name: str
+    classification: ItemClassification
+    event: bool = False
 
 class StacklandsItem(Item):
     game = "Stacklands"
 
-    def __init__(self, name, player: int = None):
-        item_data = item_table[name]
+    def __init__(self, code: int, item: ItemData, player: int = None):
         super(StacklandsItem, self).__init__(
-            name,
-            item_data.classification,
-            item_data.code,
+            item.name,
+            item.classification,
+            code,
             player
         )
+
+# Item mapping
+item_table: List[ItemData] = [
+    # Booster Packs
+    ItemData("Humble Beginnings Booster Pack"      , ItemClassification.progression),
+    ItemData("Seeking Wisdom Booster Pack"         , ItemClassification.progression),
+    ItemData("Reap & Sow Booster Pack"             , ItemClassification.progression),
+    ItemData("Curious Cuisine Booster Pack"        , ItemClassification.progression),
+    ItemData("Logic and Reason Booster Pack"       , ItemClassification.progression),
+    ItemData("The Armory Booster Pack"             , ItemClassification.progression),
+    ItemData("Explorers Booster Pack"              , ItemClassification.progression),
+    ItemData("Order and Structure Booster Pack"    , ItemClassification.progression),
     
+    # Ideas
+    ItemData("Idea: Animal Pen"                    , ItemClassification.filler),
+    ItemData("Idea: Axe"                           , ItemClassification.useful), # Getting resources faster is useful
+    ItemData("Idea: Bone Spear"                    , ItemClassification.useful), # Useful for fighting Demon
+    ItemData("Idea: Boomerang"                     , ItemClassification.useful), # Useful for fighting Demon
+    ItemData("Idea: Breeding Pen"                  , ItemClassification.filler),
+    ItemData("Idea: Brick"                         , ItemClassification.progression),
+    ItemData("Idea: Brickyard"                     , ItemClassification.progression),
+    ItemData("Idea: Butchery"                      , ItemClassification.filler),
+    ItemData("Idea: Campfire"                      , ItemClassification.progression),
+    ItemData("Idea: Chainmail Armor"               , ItemClassification.useful), # Useful for fighting Demon
+    ItemData("Idea: Chicken"                       , ItemClassification.filler),
+    ItemData("Idea: Club"                          , ItemClassification.useful), # Useful as additional fighting class
+    ItemData("Idea: Coin Chest"                    , ItemClassification.progression), # Storage is useful
+    ItemData("Idea: Cooked Meat"                   , ItemClassification.progression),
+    ItemData("Idea: Crane"                         , ItemClassification.filler),
+    ItemData("Idea: Dustbin"                       , ItemClassification.filler), 
+    ItemData("Idea: Farm"                          , ItemClassification.progression),
+    ItemData("Idea: Frittata"                      , ItemClassification.progression),
+    ItemData("Idea: Fruit Salad"                   , ItemClassification.filler),
+    ItemData("Idea: Garden"                        , ItemClassification.progression),
+    ItemData("Idea: Growth"                        , ItemClassification.progression),
+    ItemData("Idea: Hammer"                        , ItemClassification.useful), # Building faster is useful
+    ItemData("Idea: Hotpot"                        , ItemClassification.filler),
+    ItemData("Idea: House"                         , ItemClassification.progression),
+    ItemData("Idea: Iron Bar"                      , ItemClassification.progression),
+    ItemData("Idea: Iron Mine"                     , ItemClassification.progression), # Getting resources faster is useful
+    ItemData("Idea: Iron Shield"                   , ItemClassification.useful), # Useful for fighting Demon
+    ItemData("Idea: Lumber Camp"                   , ItemClassification.progression),
+    ItemData("Idea: Magic Blade"                   , ItemClassification.useful), # Useful for fighting Demon
+    ItemData("Idea: Magic Glue"                    , ItemClassification.filler),
+    ItemData("Idea: Magic Ring"                    , ItemClassification.filler),
+    ItemData("Idea: Magic Staff"                   , ItemClassification.useful), # Useful for fighting Demon / 'Train a Wizard' quest, but can create Magic Wand instead
+    ItemData("Idea: Magic Tome"                    , ItemClassification.filler),
+    ItemData("Idea: Magic Wand"                    , ItemClassification.progression),
+    ItemData("Idea: Market"                        , ItemClassification.progression),
+    ItemData("Idea: Milkshake"                     , ItemClassification.filler),
+    ItemData("Idea: Omelette"                      , ItemClassification.progression),
+    ItemData("Idea: Offspring"                     , ItemClassification.progression),
+    ItemData("Idea: Pickaxe"                       , ItemClassification.useful), # Getting resources faster is useful
+    ItemData("Idea: Plank"                         , ItemClassification.progression),
+    ItemData("Idea: Quarry"                        , ItemClassification.progression),
+    ItemData("Idea: Resource Chest"                , ItemClassification.useful), # Storage is useful
+    ItemData("Idea: Resource Magnet"               , ItemClassification.filler),
+    ItemData("Idea: Sawmill"                       , ItemClassification.progression), # Getting resources faster is useful
+    ItemData("Idea: Shed"                          , ItemClassification.progression),
+    ItemData("Idea: Slingshot"                     , ItemClassification.progression),
+    ItemData("Idea: Smelter"                       , ItemClassification.progression),
+    ItemData("Idea: Smithy"                        , ItemClassification.progression),
+    ItemData("Idea: Spear"                         , ItemClassification.progression), # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
+    ItemData("Idea: Spiked Plank"                  , ItemClassification.filler),
+    ItemData("Idea: Stew"                          , ItemClassification.filler), # Food types are useful
+    ItemData("Idea: Stick"                         , ItemClassification.progression),
+    ItemData("Idea: Stove"                         , ItemClassification.progression), # Useful for keeping enough food, but not required
+    ItemData("Idea: Sword"                         , ItemClassification.useful), # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
+    ItemData("Idea: Temple"                        , ItemClassification.progression),
+    ItemData("Idea: Throwing Stars"                , ItemClassification.progression),
+    ItemData("Idea: University"                    , ItemClassification.filler),
+    ItemData("Idea: Warehouse"                     , ItemClassification.useful), # Higher card limit is useful
+    ItemData("Idea: Wizard Robe"                   , ItemClassification.filler),
+    ItemData("Idea: Wooden Shield"                 , ItemClassification.useful), # Useful for 'Combat level 20' but are other things available
+    
+    # Resources
+    ItemData("Berry x5"                            , ItemClassification.filler),
+    ItemData("Flint x5"                            , ItemClassification.filler),
+    ItemData("Iron Ore x5"                         , ItemClassification.filler),
+    ItemData("Poop x5"                             , ItemClassification.filler),
+    ItemData("Stone x5"                            , ItemClassification.filler),
+    ItemData("Wood x5"                             , ItemClassification.filler),
+    
+    # Traps (to be implemented...)
+    # - Spawn enemies onto the board?
+    # - 'Get Pooped' item that spawns a bunch of poop?
 
-class ItemData(NamedTuple):
-    code: Optional[int]
-    classification: ItemClassification = ItemClassification.filler
-    event: bool = False
+    ItemData("Victory"                             , ItemClassification.progression, True),
+]
 
-item_table: Dict[str, ItemData] = {
-    "Idea: Stick":          ItemData(90001, ItemClassification.progression  ),
-    "Idea: Campfire":       ItemData(90002, ItemClassification.progression  ),
-    "Idea: Plank":          ItemData(90003, ItemClassification.progression  ),
-    "Idea: Sawmill":        ItemData(90004, ItemClassification.progression  ),
-    "Idea: Iron Bar":       ItemData(90005, ItemClassification.progression  ),
-    "Idea: Brick":          ItemData(90006, ItemClassification.progression  ),
-    "Idea: Smelter":        ItemData(90007, ItemClassification.progression  ),
-    "Filler Item 1":        ItemData(90008, ItemClassification.filler       ),
-    "Filler Item 2":        ItemData(90009, ItemClassification.filler       ),
-    "Filler Item 3":        ItemData(90010, ItemClassification.filler       ),
-    "Filler Item 4":        ItemData(90010, ItemClassification.filler       ),
-    "Filler Item 5":        ItemData(90011, ItemClassification.filler       ),
-
-    # Events
-    "Campfire": ItemData(None, ItemClassification.progression, True),
-    "Sawmill":  ItemData(None, ItemClassification.progression, True),
-    "Smelter":  ItemData(None, ItemClassification.progression, True),
-    "Victory":  ItemData(None, ItemClassification.progression, True),
-}
-
+# Event mapping table
 event_table: Dict[str, str] = {
-    "Ability to Build Campfire":    "Campfire",
-    "Ability to Build Sawmill":     "Sawmill",
-    "Ability to Build Smelter":     "Smelter",
-    "Defeat Boss":                  "Victory",
+    "Complete the Goal": "Victory"
 }
+
+# Item group mapping table
+group_table: Dict[str, set[str]] = {
+    "All Ideas": set(item.name for item in item_table if item.name.startswith("Idea:")),
+    "All Booster Packs": set(item.name for item in item_table if item.name.endswith("Booster Pack")),
+}
+
+base_id: int = 91000
+current_id: int = base_id
+
+name_to_id = {}
+
+# Create name-to-id lookup
+for item in item_table:
+    name_to_id[item.name] = current_id if not item.event else None
+    current_id += 1
 
 # Create all items
 def create_all_items(world: MultiWorld, player: int) -> None:
     pool = []
-    for name, item in item_table.items():
-        if item.event == False:
-            item = StacklandsItem(name, player)
-            pool.append(item)
 
-    # Add items to the pool
+    # Get list of items to exclude if in starting inventory
+    exclude = [item for item in world.precollected_items[player]]
+
+    # Gather items
+    for item in item_table:
+
+        # If item is not an event...
+        if not item.event:
+            item_obj = StacklandsItem(name_to_id[item.name], item, player)
+
+            # If item is not in starting inventory, add to pool
+            if item_obj not in exclude:
+                pool.append(item_obj)
+
+    # Add all items to pool
     world.itempool += pool
 
-    ## Add event items
+    # Add victory event item
     for event, item in event_table.items():
-        event_item = StacklandsItem(item, player)
-        world.get_location(event, player).place_locked_item(event_item)
-
-    # [
-    ### Mainland Items ###
-
-    # # Booster Packs
-    # { "name": "Humble Beginnings Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Seeking Wisdom Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Reap & Sow Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Curious Cuisine Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Logic and Reason Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "The Armory Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Explorers Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Order and Structure Booster Pack", "classification": ItemClassification.progression, "count": 1 },
-    
-    # # Ideas
-    # { "name": "Idea: Animal Pen", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Axe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
-    # { "name": "Idea: Bone Spear", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    # { "name": "Idea: Boomerang", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    # { "name": "Idea: Breeding Pen", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Brick", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Brickyard", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Butchery", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Campfire", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Chainmail Armor", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    # { "name": "Idea: Chicken", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Club", "classification": ItemClassification.useful, "count": 1 }, # Useful as additional fighting class
-    # { "name": "Idea: Coin Chest", "classification": ItemClassification.progression, "count": 1 }, # Storage is useful
-    # { "name": "Idea: Cooked Meat", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Crane", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Dustbin", "classification": ItemClassification.filler, "count": 1 }, 
-    # { "name": "Idea: Farm", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Frittata", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Fruit Salad", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Garden", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Growth", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Hammer", "classification": ItemClassification.useful, "count": 1 }, # Building faster is useful
-    # { "name": "Idea: Hotpot", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: House", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Iron Bar", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Iron Mine", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
-    # { "name": "Idea: Iron Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    # { "name": "Idea: Lumber Camp", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Magic Blade", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon
-    # { "name": "Idea: Magic Glue", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Magic Ring", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Magic Staff", "classification": ItemClassification.useful, "count": 1 }, # Useful for fighting Demon / 'Train a Wizard' quest, but can create Magic Wand instead
-    # { "name": "Idea: Magic Tome", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Magic Wand", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Market", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Milkshake", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Omelette", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Offspring", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Pickaxe", "classification": ItemClassification.useful, "count": 1 }, # Getting resources faster is useful
-    # { "name": "Idea: Plank", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Quarry", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Resource Chest", "classification": ItemClassification.useful, "count": 1 }, # Storage is useful
-    # { "name": "Idea: Resource Magnet", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Sawmill", "classification": ItemClassification.progression, "count": 1 }, # Getting resources faster is useful
-    # { "name": "Idea: Shed", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Slingshot", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Smelter", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Smithy", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Spear", "classification": ItemClassification.progression, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
-    # { "name": "Idea: Spiked Plank", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Stew", "classification": ItemClassification.filler, "count": 1 }, # Food types are useful
-    # { "name": "Idea: Stick", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Stove", "classification": ItemClassification.progression, "count": 1 }, # Useful for keeping enough food, but not required
-    # { "name": "Idea: Sword", "classification": ItemClassification.useful, "count": 1 }, # Useful for completing 'Train Militia' or 'Combat Level 20' but there are other options
-    # { "name": "Idea: Temple", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: Throwing Stars", "classification": ItemClassification.progression, "count": 1 },
-    # { "name": "Idea: University", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Warehouse", "classification": ItemClassification.useful, "count": 1 }, # Higher card limit is useful
-    # { "name": "Idea: Wizard Robe", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Idea: Wooden Shield", "classification": ItemClassification.useful, "count": 1 }, # Useful for 'Combat level 20' but are other things available
-    
-    # # Equipment
-    # # { "name": "Club", "classification": ItemClassification.filler, "count": 1 },
-    # # { "name": "Magic Wand", "classification": ItemClassification.filler, "count": 1 },
-    # # { "name": "Spear", "classification": ItemClassification.filler, "count": 1 },
-    # # { "name": "Sword", "classification": ItemClassification.filler, "count": 1 },
-    # # { "name": "Wooden Shield", "classification": ItemClassification.filler, "count": 1 },
-    
-    # # Resources
-    # { "name": "Berry x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Flint x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Iron Ore x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Poop x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Stone x5", "classification": ItemClassification.filler, "count": 1 },
-    # { "name": "Wood x5", "classification": ItemClassification.filler, "count": 1 }
-    
-    # Traps (to be implemented..)
-    # - Spawn enemies onto the board?
-    # - 'Get Pooped' item that spawns a bunch of poop?
-# ]
-
-# item_group_table: Dict[str, Set[str]] = {
-#     "All Ideas": set(item["name"] for item in items_table if item["name"].startswith("Idea:")),
-#     "All Booster Packs": set(item["name"] for item in items_table if item["name"].endswith("Booster Pack")),
-#     "Basic Booster Packs": {"Humble Beginnings Booster Pack", "Seeking Wisdom Booster Pack", "Reap & Sow Booster Pack"}
-# }
-    
-# # ID assignment
-# base_id: int = 92000
-# current_id: int = base_id
-
-# # Lookups
-# lookup_id_to_name = {}
-# lookup_name_to_id = {}   
-
-# # Create item lookups
-# for item in items_table:
-    
-#     # Add to lookups
-#     lookup_id_to_name[current_id] = item["name"]
-#     lookup_name_to_id[item["name"]] = current_id
-    
-#     # Increment ID
-#     current_id += 1
-
-# Create an item as a StacklandsItem object
-# def create_item(player: int, item: ItemData) -> StacklandsItem:
-#     return StacklandsItem(item["name"], item["classification"], lookup_name_to_id[item["name"]], player=player)
-
-# # Add all items to the item pool
-# def create_all_items(world: MultiWorld, player: int, options: StacklandsOptions):
-#     for item in items_table:
-        
-#         # Exclude Humble Beginnings if 'basic pack' option is true
-#         if options.basic_pack.value and item["name"] == "Humble Beginnings Booster Pack":
-#             continue
-
-#         for _ in range(item["count"]):
-#             world.itempool.append(create_item(player, item))
+        world.get_location(event, player).place_locked_item(Item(item, ItemClassification.progression, None, player))

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -94,8 +94,8 @@ locations_table: List[LocationData] = [
     # 'Longevity' Category
     {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
 
     # 'Side Quests' Category
     {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -1,131 +1,128 @@
-from typing import Dict, Optional, NamedTuple
-from BaseClasses import Location, LocationProgressType
+from typing import Dict, List, NamedTuple
+from BaseClasses import Location, LocationProgressType, Region
+
+class LocationData(NamedTuple):
+    name: str
+    region: str
+    progress_type: LocationProgressType
+    event: bool = False
 
 class StacklandsLocation(Location):
     game = "Stacklands"
 
-class LocationData(NamedTuple):
-    code: Optional[int]
-    region: str
-    progress_type: LocationProgressType =  LocationProgressType.DEFAULT
-    event: bool = False
+    def __init__(self, player: int, loc: LocationData, code: int = None, region: Region = None):
+        super(StacklandsLocation, self).__init__(
+            player,
+            loc.name,
+            code,
+            region
+        )
+
+        # Set progress type
+        self.progress_type = loc.progress_type
 
 # Locations table
-location_table: Dict[str, LocationData] = {
+location_table: List[LocationData] = [
 
-    # Locations
-    "Open the Booster Pack":                LocationData(91001, "Mainland"),
-    "Make a Stick from Wood":               LocationData(91002, "Mainland"),
-    "Start a Campfire":                     LocationData(91003, "Mainland"),
-    "Build a Smelter":                      LocationData(91004, "Mainland"),
-    "Build a Sawmill":                      LocationData(91005, "Mainland"),
-    "Task 1":                               LocationData(91006, "Mainland"),
-    "Task 2":                               LocationData(91007, "Mainland"),
-    "Task 3":                               LocationData(91008, "Mainland"),
-    "Task 4":                               LocationData(91009, "Mainland"),
-    "Task 5":                               LocationData(91010, "Mainland"),
-    "Task 6":                               LocationData(91011, "Mainland"),
-    "Bring the Goblet to the Temple":       LocationData(91012, "Mainland"),
+    # 'Welcome' Category
+    LocationData("Open the Booster Pack"                               , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Drag the Villager on top of the Berry Bush"          , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Mine a Rock using a Villager"                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Sell a Card"                                         , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Buy the Humble Beginnings Pack"                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Harvest a Tree using a Villager"                     , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Make a Stick from Wood"                              , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Pause using the play icon in the top right corner"   , "Mainland", LocationProgressType.EXCLUDED),
+    LocationData("Grow a Berry Bush using Soil"                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a House"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Get a Second Villager"                               , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Create Offspring"                                    , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'The Grand Scheme' Category
+    LocationData("Get 3 Villagers"                                     , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Find the Catacombs"                                  , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Find a mysterious artifact"                          , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Temple"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Bring the Goblet to the Temple"                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Kill the Demon"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Kill the Demon Lord"                                 , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Power & Skill' Category
+    LocationData("Train Militia"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Kill a Rat"                                          , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Kill a Skeleton"                                     , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Strengthening Up' Category
+    LocationData("Make a Villager wear a Rabbit Hat"                   , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Smithy"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Train a Wizard"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have a Villager with Combat Level 20"                , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Train a Ninja"                                       , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Potluck' Category
+    LocationData("Start a Campfire"                                    , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Cook Raw Meat"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Cook an Omelette"                                    , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Cook a Frittata"                                     , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Discovery' Category
+    LocationData("Explore a Forest"                                    , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Explore a Mountain"                                  , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Open a Treasure Chest"                               , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Find a Graveyard"                                    , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Get a Dog"                                           , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Train an Explorer"                                   , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Buy something from a Travelling Cart"                , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Ways and Means' Category
+    LocationData("Have 5 Ideas"                                        , "Mainland", LocationProgressType.EXCLUDED),
+    LocationData("Have 10 Ideas"                                       , "Mainland", LocationProgressType.EXCLUDED),
+    LocationData("Have 10 Wood"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 10 Stone"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Get an Iron Bar"                                     , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 5 Food"                                         , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 10 Food"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 20 Food"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 50 Food"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 10 Coins"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 30 Coins"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Have 50 Coins"                                       , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Construction' Category
+    LocationData("Have 3 Houses"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Shed"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Quarry"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Lumber Camp"                                 , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Farm"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Brickyard"                                   , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Sell a Card at a Market"                             , "Mainland", LocationProgressType.DEFAULT),
+    
+    # 'Longevity' Category
+    LocationData("Reach Moon 6"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Reach Moon 12"                                       , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Reach Moon 24"                                       , "Mainland", LocationProgressType.EXCLUDED),
+    LocationData("Reach Moon 36"                                       , "Mainland", LocationProgressType.EXCLUDED),
 
-    # Events
-    "Ability to Build Campfire":            LocationData(None, "Mainland", event=True),
-    "Ability to Build Sawmill":             LocationData(None, "Mainland", event=True),
-    "Ability to Build Smelter":             LocationData(None, "Mainland", event=True),
-    "Defeat Boss":                          LocationData(None, "Mainland", event=True),
+    # 'Side Quests' Category
+    LocationData("Build a Garden"                                      , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Sawmill"                                     , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Mine"                                        , "Mainland", LocationProgressType.DEFAULT),
+    LocationData("Build a Smelter"                                     , "Mainland", LocationProgressType.DEFAULT),
+
+    # Event location
+    LocationData("Complete the Goal"                                   , "Mainland", LocationProgressType.DEFAULT, True),
+]
+
+event_table: Dict[str, str] = {
+    "Complete the Goal", "Victory"
 }
 
+base_id: int = 92000
+current_id: int = base_id
 
-# locations_table: List[LocationData] = [
-    
-    # Mainland Quests
-    
-    # 'Welcome' Category
-    # {"name": "Open the Booster Pack",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Drag the Villager on top of the Berry Bush",          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Mine a Rock using a Villager",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Sell a Card",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Buy the Humble Beginnings Pack",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Harvest a Tree using a Villager",                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Pause using the play icon in the top right corner",   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Grow a Berry Bush using Soil",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a House",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Create Offspring",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    
-    # # 'The Grand Scheme' Category
-    # # {"name": "Unlock All Packs", "region": "Mainland"}, <- Can ONLY be unlocked by receiving all packs from checks, seems pointless? (Also this quest triggers when Order and Structure pack is unlocked, so usually triggers far too early)
-    # {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Find the Catacombs",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Find a mysterious artifact",                          "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Build a Temple",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Bring the Goblet to the Temple",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Kill the Demon",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Kill the Demon Lord",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    
-    # # 'Power & Skill' Category
-    # {"name": "Train Militia",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Kill a Rat",                                          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Kill a Skeleton",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    
-    # # 'Strengthening Up' Category
-    # # {"name": "Train an Archer", "region": "Mainland"}, <- Bow / Crossbow require Rope (from Island) or is a chance drop from Elf Archer - seems unfair.
-    # {"name": "Make a Villager wear a Rabbit Hat",                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a Smithy",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Train a Wizard",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # # {"name": "Equip an Archer with a Quiver", "region": "Mainland"}, <- Is a chance drop from Elf Archer - seems unfair.
-    # {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Train a Ninja",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    
-    # # 'Potluck' Category
-    # {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Cook an Omelette",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Cook a Frittata",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    
-    # # 'Discovery' Category
-    # {"name": "Explore a Forest",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Explore a Mountain",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Open a Treasure Chest",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Find a Graveyard",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Train an Explorer",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    
-    # # 'Ways and Means' Category
-    # {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Have 10 Wood",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Have 10 Stone",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Get an Iron Bar",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Have 5 Food",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Have 10 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Have 10 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    
-    # # 'Construction' Category
-    # {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    
-    # # 'Longevity' Category
-    # {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    # {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+name_to_id = {}
 
-    # # 'Side Quests' Category
-    # {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    # {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-# ]
-
-
+# Create location lookup
+for location in location_table:
+    name_to_id[location.name] = current_id if not location.event else None
+    current_id += 1

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -1,5 +1,5 @@
 from typing import List, TypedDict
-from BaseClasses import Location
+from BaseClasses import Location, LocationProgressType
 
 class StacklandsLocation(Location):
     game = "Stacklands"
@@ -8,6 +8,7 @@ class StacklandsLocation(Location):
 class LocationData(TypedDict):
     name: str
     region: str
+    classification: LocationProgressType
 
 # Locations table
 locations_table: List[LocationData] = [
@@ -15,86 +16,92 @@ locations_table: List[LocationData] = [
     # Mainland Quests
     
     # 'Welcome' Category
-    {"name": "Open the Booster Pack", "region": "Mainland"},
-    {"name": "Drag the Villager on top of the Berry Bush", "region": "Mainland"},
-    {"name": "Mine a Rock using a Villager", "region": "Mainland"},
-    {"name": "Sell a Card", "region": "Mainland"},
-    {"name": "Buy the Humble Beginnings Pack", "region": "Mainland"},
-    {"name": "Harvest a Tree using a Villager", "region": "Mainland"},
-    {"name": "Make a Stick from Wood", "region": "Mainland"},
-    {"name": "Pause using the play icon in the top right corner", "region": "Mainland"},
-    {"name": "Grow a Berry Bush using Soil", "region": "Mainland"},
-    {"name": "Build a House", "region": "Mainland"},
-    {"name": "Get a Second Villager", "region": "Mainland"},
-    {"name": "Create Offspring", "region": "Mainland"},
+    {"name": "Open the Booster Pack",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Drag the Villager on top of the Berry Bush",          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Mine a Rock using a Villager",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Sell a Card",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Buy the Humble Beginnings Pack",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Harvest a Tree using a Villager",                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Pause using the play icon in the top right corner",   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Grow a Berry Bush using Soil",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a House",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Create Offspring",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     
     # 'The Grand Scheme' Category
     # {"name": "Unlock All Packs", "region": "Mainland"}, <- Can ONLY be unlocked by receiving all packs from checks, seems pointless? (Also this quest triggers when Order and Structure pack is unlocked, so usually triggers far too early)
-    {"name": "Get 3 Villagers", "region": "Mainland"},
-    {"name": "Find the Catacombs", "region": "Mainland"},
-    {"name": "Find a mysterious artifact", "region": "Mainland"},
-    {"name": "Build a Temple", "region": "Mainland"},
-    {"name": "Bring the Goblet to the Temple", "region": "Mainland"},
-    {"name": "Kill the Demon", "region": "Mainland"},
-    {"name": "Kill the Demon Lord", "region": "Mainland"},
+    {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Find the Catacombs",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Find a mysterious artifact",                          "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Temple",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Bring the Goblet to the Temple",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Kill the Demon",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Kill the Demon Lord",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     
     # 'Power & Skill' Category
-    {"name": "Train Militia", "region": "Mainland"},
-    {"name": "Kill a Rat", "region": "Mainland"},
-    {"name": "Kill a Skeleton", "region": "Mainland"},
+    {"name": "Train Militia",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Kill a Rat",                                          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Kill a Skeleton",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Strengthening Up' Category
     # {"name": "Train an Archer", "region": "Mainland"}, <- Bow / Crossbow require Rope (from Island) or is a chance drop from Elf Archer - seems unfair.
-    {"name": "Make a Villager wear a Rabbit Hat", "region": "Mainland"},
-    {"name": "Build a Smithy", "region": "Mainland"},
-    {"name": "Train a Wizard", "region": "Mainland"},
+    {"name": "Make a Villager wear a Rabbit Hat",                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Smithy",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Train a Wizard",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     # {"name": "Equip an Archer with a Quiver", "region": "Mainland"}, <- Is a chance drop from Elf Archer - seems unfair.
-    {"name": "Have a Villager with Combat Level 20", "region": "Mainland"},
-    {"name": "Train a Ninja", "region": "Mainland"},
+    {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Train a Ninja",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Potluck' Category
-    {"name": "Start a Campfire", "region": "Mainland"},
-    {"name": "Cook Raw Meat", "region": "Mainland"},
-    {"name": "Cook an Omelette", "region": "Mainland"},
-    {"name": "Cook a Frittata", "region": "Mainland"},
+    {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Cook an Omelette",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Cook a Frittata",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Discovery' Category
-    {"name": "Explore a Forest", "region": "Mainland"},
-    {"name": "Explore a Mountain", "region": "Mainland"},
-    {"name": "Open a Treasure Chest", "region": "Mainland"},
-    {"name": "Find a Graveyard", "region": "Mainland"},
-    {"name": "Get a Dog", "region": "Mainland"},
-    {"name": "Train an Explorer", "region": "Mainland"},
-    {"name": "Buy something from a Travelling Cart", "region": "Mainland"},
+    {"name": "Explore a Forest",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Explore a Mountain",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Open a Treasure Chest",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Find a Graveyard",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Train an Explorer",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Ways and Means' Category
-    {"name": "Have 5 Ideas", "region": "Mainland"},
-    {"name": "Have 10 Ideas", "region": "Mainland"},
-    {"name": "Have 10 Wood", "region": "Mainland"},
-    {"name": "Have 10 Stone", "region": "Mainland"},
-    {"name": "Get an Iron Bar", "region": "Mainland"},
-    {"name": "Have 5 Food", "region": "Mainland"},
-    {"name": "Have 10 Food", "region": "Mainland"},
-    {"name": "Have 20 Food", "region": "Mainland"},
-    {"name": "Have 50 Food", "region": "Mainland"},
-    {"name": "Have 10 Coins", "region": "Mainland"},
-    {"name": "Have 30 Coins", "region": "Mainland"},
-    {"name": "Have 50 Coins", "region": "Mainland"},
+    {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 10 Wood",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 10 Stone",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Get an Iron Bar",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Have 5 Food",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 10 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 10 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Construction' Category
-    {"name": "Have 3 Houses", "region": "Mainland"},
-    {"name": "Build a Shed", "region": "Mainland"},
-    {"name": "Build a Quarry", "region": "Mainland"},
-    {"name": "Build a Lumber Camp", "region": "Mainland"},
-    {"name": "Build a Farm", "region": "Mainland"},
-    {"name": "Build a Brickyard", "region": "Mainland"},
-    {"name": "Sell a Card at a Market", "region": "Mainland"},
+    {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Longevity' Category
-    {"name": "Reach Moon 6", "region": "Mainland"},
-    {"name": "Reach Moon 12", "region": "Mainland"},
-    {"name": "Reach Moon 24", "region": "Mainland"},
-    {"name": "Reach Moon 36", "region": "Mainland"},
+    {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+
+    # 'Side Quests' Category
+    {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
 ]
 
 base_id: int = 91000

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -22,16 +22,16 @@ locations_table: List[LocationData] = [
     {"name": "Sell a Card",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Buy the Humble Beginnings Pack",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Harvest a Tree using a Villager",                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Pause using the play icon in the top right corner",   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Grow a Berry Bush using Soil",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Build a House",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Create Offspring",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     
     # 'The Grand Scheme' Category
     # {"name": "Unlock All Packs", "region": "Mainland"}, <- Can ONLY be unlocked by receiving all packs from checks, seems pointless? (Also this quest triggers when Order and Structure pack is unlocked, so usually triggers far too early)
-    {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Find the Catacombs",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Find a mysterious artifact",                          "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Build a Temple",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
@@ -50,12 +50,12 @@ locations_table: List[LocationData] = [
     {"name": "Build a Smithy",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Train a Wizard",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     # {"name": "Equip an Archer with a Quiver", "region": "Mainland"}, <- Is a chance drop from Elf Archer - seems unfair.
-    {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Train a Ninja",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Potluck' Category
-    {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Cook an Omelette",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Cook a Frittata",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
@@ -64,43 +64,43 @@ locations_table: List[LocationData] = [
     {"name": "Explore a Mountain",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Open a Treasure Chest",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Find a Graveyard",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     {"name": "Train an Explorer",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     
     # 'Ways and Means' Category
-    {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     {"name": "Have 10 Wood",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Have 10 Stone",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Get an Iron Bar",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Have 5 Food",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Have 10 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     {"name": "Have 10 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     
     # 'Construction' Category
-    {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     
     # 'Longevity' Category
-    {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
 
     # 'Side Quests' Category
     {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
 ]
 

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -85,10 +85,10 @@ locations_table: List[LocationData] = [
     # 'Construction' Category
     {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
     # 'Longevity' Category
@@ -98,10 +98,10 @@ locations_table: List[LocationData] = [
     {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
 
     # 'Side Quests' Category
-    {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
 ]
 
 base_id: int = 91000

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -1,120 +1,131 @@
-from typing import List, TypedDict
+from typing import Dict, Optional, NamedTuple
 from BaseClasses import Location, LocationProgressType
 
 class StacklandsLocation(Location):
     game = "Stacklands"
 
-
-class LocationData(TypedDict):
-    name: str
+class LocationData(NamedTuple):
+    code: Optional[int]
     region: str
-    classification: LocationProgressType
+    progress_type: LocationProgressType =  LocationProgressType.DEFAULT
+    event: bool = False
 
 # Locations table
-locations_table: List[LocationData] = [
+location_table: Dict[str, LocationData] = {
+
+    # Locations
+    "Open the Booster Pack":                LocationData(91001, "Mainland"),
+    "Make a Stick from Wood":               LocationData(91002, "Mainland"),
+    "Start a Campfire":                     LocationData(91003, "Mainland"),
+    "Build a Smelter":                      LocationData(91004, "Mainland"),
+    "Build a Sawmill":                      LocationData(91005, "Mainland"),
+    "Task 1":                               LocationData(91006, "Mainland"),
+    "Task 2":                               LocationData(91007, "Mainland"),
+    "Task 3":                               LocationData(91008, "Mainland"),
+    "Task 4":                               LocationData(91009, "Mainland"),
+    "Task 5":                               LocationData(91010, "Mainland"),
+    "Task 6":                               LocationData(91011, "Mainland"),
+    "Bring the Goblet to the Temple":       LocationData(91012, "Mainland"),
+
+    # Events
+    "Ability to Build Campfire":            LocationData(None, "Mainland", event=True),
+    "Ability to Build Sawmill":             LocationData(None, "Mainland", event=True),
+    "Ability to Build Smelter":             LocationData(None, "Mainland", event=True),
+    "Defeat Boss":                          LocationData(None, "Mainland", event=True),
+}
+
+
+# locations_table: List[LocationData] = [
     
     # Mainland Quests
     
     # 'Welcome' Category
-    {"name": "Open the Booster Pack",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Drag the Villager on top of the Berry Bush",          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Mine a Rock using a Villager",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Sell a Card",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Buy the Humble Beginnings Pack",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Harvest a Tree using a Villager",                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Pause using the play icon in the top right corner",   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Grow a Berry Bush using Soil",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a House",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Create Offspring",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Open the Booster Pack",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Drag the Villager on top of the Berry Bush",          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Mine a Rock using a Villager",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Sell a Card",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Buy the Humble Beginnings Pack",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Harvest a Tree using a Villager",                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Make a Stick from Wood",                              "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Pause using the play icon in the top right corner",   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Grow a Berry Bush using Soil",                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a House",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Get a Second Villager",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Create Offspring",                                    "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     
-    # 'The Grand Scheme' Category
-    # {"name": "Unlock All Packs", "region": "Mainland"}, <- Can ONLY be unlocked by receiving all packs from checks, seems pointless? (Also this quest triggers when Order and Structure pack is unlocked, so usually triggers far too early)
-    {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Find the Catacombs",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Find a mysterious artifact",                          "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Temple",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Bring the Goblet to the Temple",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Kill the Demon",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Kill the Demon Lord",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # # 'The Grand Scheme' Category
+    # # {"name": "Unlock All Packs", "region": "Mainland"}, <- Can ONLY be unlocked by receiving all packs from checks, seems pointless? (Also this quest triggers when Order and Structure pack is unlocked, so usually triggers far too early)
+    # {"name": "Get 3 Villagers",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Find the Catacombs",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Find a mysterious artifact",                          "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Build a Temple",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Bring the Goblet to the Temple",                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Kill the Demon",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Kill the Demon Lord",                                 "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
     
-    # 'Power & Skill' Category
-    {"name": "Train Militia",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Kill a Rat",                                          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Kill a Skeleton",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # # 'Power & Skill' Category
+    # {"name": "Train Militia",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Kill a Rat",                                          "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Kill a Skeleton",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
-    # 'Strengthening Up' Category
-    # {"name": "Train an Archer", "region": "Mainland"}, <- Bow / Crossbow require Rope (from Island) or is a chance drop from Elf Archer - seems unfair.
-    {"name": "Make a Villager wear a Rabbit Hat",                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Smithy",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Train a Wizard",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    # {"name": "Equip an Archer with a Quiver", "region": "Mainland"}, <- Is a chance drop from Elf Archer - seems unfair.
-    {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Train a Ninja",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # # 'Strengthening Up' Category
+    # # {"name": "Train an Archer", "region": "Mainland"}, <- Bow / Crossbow require Rope (from Island) or is a chance drop from Elf Archer - seems unfair.
+    # {"name": "Make a Villager wear a Rabbit Hat",                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a Smithy",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Train a Wizard",                                      "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # # {"name": "Equip an Archer with a Quiver", "region": "Mainland"}, <- Is a chance drop from Elf Archer - seems unfair.
+    # {"name": "Have a Villager with Combat Level 20",                "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Train a Ninja",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
-    # 'Potluck' Category
-    {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Cook an Omelette",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Cook a Frittata",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # # 'Potluck' Category
+    # {"name": "Start a Campfire",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Cook Raw Meat",                                       "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Cook an Omelette",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Cook a Frittata",                                     "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
-    # 'Discovery' Category
-    {"name": "Explore a Forest",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Explore a Mountain",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Open a Treasure Chest",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Find a Graveyard",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Train an Explorer",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # # 'Discovery' Category
+    # {"name": "Explore a Forest",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Explore a Mountain",                                  "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Open a Treasure Chest",                               "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Find a Graveyard",                                    "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Get a Dog",                                           "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Train an Explorer",                                   "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Buy something from a Travelling Cart",                "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     
-    # 'Ways and Means' Category
-    {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Have 10 Wood",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 10 Stone",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Get an Iron Bar",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Have 5 Food",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 10 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Have 10 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # # 'Ways and Means' Category
+    # {"name": "Have 5 Ideas",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Have 10 Ideas",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Have 10 Wood",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Have 10 Stone",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Get an Iron Bar",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Have 5 Food",                                         "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Have 10 Food",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Have 20 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Have 50 Food",                                        "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Have 10 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Have 30 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Have 50 Coins",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
     
-    # 'Construction' Category
-    {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # # 'Construction' Category
+    # {"name": "Have 3 Houses",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Build a Shed",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a Quarry",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Build a Lumber Camp",                                 "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a Farm",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a Brickyard",                                   "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Sell a Card at a Market",                             "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
     
-    # 'Longevity' Category
-    {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
-    {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # # 'Longevity' Category
+    # {"name": "Reach Moon 6",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Reach Moon 12",                                       "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Reach Moon 24",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
+    # {"name": "Reach Moon 36",                                       "region": "Mainland",   "classification": LocationProgressType.EXCLUDED },
 
-    # 'Side Quests' Category
-    {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-    {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
-    {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
-]
+    # # 'Side Quests' Category
+    # {"name": "Build a Garden",                                      "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Build a Sawmill",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+    # {"name": "Build a Mine",                                        "region": "Mainland",   "classification": LocationProgressType.DEFAULT  },
+    # {"name": "Build a Smelter",                                     "region": "Mainland",   "classification": LocationProgressType.PRIORITY },
+# ]
 
-base_id: int = 91000
-current_id: int = base_id
 
-lookup_id_to_name = {}
-lookup_name_to_id = {}
-    
-for location in locations_table:
-        
-    # Add to lookups
-    lookup_id_to_name[current_id] = location["name"]
-    lookup_name_to_id[location["name"]] = current_id
-        
-    # Increment ID
-    current_id += 1

--- a/worlds/stacklands/Options.py
+++ b/worlds/stacklands/Options.py
@@ -1,20 +1,5 @@
 from dataclasses import dataclass
-from Options import Choice, DeathLink, PerGameCommonOptions, Range, Toggle
-
-class BasicPackOnStart(Toggle):
-    """
-    Whether or not to start the run with the Humble Beginnings booster pack already unlocked to prevent starving 
-    at the end of Moon 2 due from starvation from not being able to buy a booster pack.
-    """
-    display_name = "Start with Humble Beginnings Booster Pack"
-
-# To be implemented in future...
-# class DeathLinkOffset(Range):
-#     """How many villager deaths will trigger a DeathLink."""
-#     display_name = "DeathLink Offset"
-#     range_start = 1
-#     range_end = 10
-#     default = 1
+from Options import Choice, DeathLink, PerGameCommonOptions, StartInventory, Toggle
     
 # More options to be implemented in future...
 class Goal(Choice):
@@ -35,20 +20,8 @@ class PauseEnabled(Toggle):
     """
     display_name = "Pausing Enabled"
 
-# To be implemented in future...
-# class VillagerHP(Range):
-#     """How much base HP Villagers will have (before equipment bonuses)"""
-#     display_name = "Villager HP"
-#     range_start = 5
-#     range_end = 30
-#     default = 15
-
 @dataclass
 class StacklandsOptions(PerGameCommonOptions):
-    basic_pack: BasicPackOnStart
     death_link: DeathLink
-    # death_link_offset: DeathLinkOffset
     goal: Goal
-    pause_enabled: PauseEnabled
-    # villager_hp: VillagerHP
-    
+    pause_enabled: PauseEnabled    

--- a/worlds/stacklands/Regions.py
+++ b/worlds/stacklands/Regions.py
@@ -1,17 +1,29 @@
 import logging
 from typing import List
 from BaseClasses import Entrance, MultiWorld, Region
-from .Locations import StacklandsLocation, location_table
-from .Options import StacklandsOptions
+from .Locations import LocationData, StacklandsLocation, location_table, name_to_id as location_lookup
 
 # Create a region
-def create_region(world: MultiWorld, player: int, name: str, locations: List[str]=None, exits: List[str]=None) -> Region:
+def create_region(world: MultiWorld, player: int, name: str, locations: List[LocationData]=None, exits: List[str]=None) -> Region:
+    
+    # Get relevant options
+    pause_enabled = world.worlds[player].options.pause_enabled.value
+    goal = world.worlds[player].options.goal.value
+
     region = Region(name, player, world)
 
     if locations:
         for location in locations:
-            loc_id = location_table[location].code
-            loc_obj = StacklandsLocation(player, location, loc_id, region)
+
+            # Skip this location if pausing is not enabled
+            if not pause_enabled and location.name == "Pause using the play icon in the top right corner":
+                continue
+            
+            # Skip this location if the goal is set to 'Kill the Demon'
+            if goal == 0 and location.name == "Kill the Demon Lord":
+                continue
+
+            loc_obj = StacklandsLocation(player, location, location_lookup[location.name], region)
             region.locations.append(loc_obj)
 
     if exits:
@@ -25,7 +37,7 @@ def create_all_regions(world: MultiWorld, player: int):
 
     world.regions += [
         create_region(world, player, "Menu", None, [ "Start" ]),
-        create_region(world, player, "Mainland", [name for name, loc in location_table.items() if loc.region == "Mainland"])
+        create_region(world, player, "Mainland", [location for location in location_table if location.region == "Mainland"])
     ]
 
     # Connect menu region to entrance of mainland

--- a/worlds/stacklands/Regions.py
+++ b/worlds/stacklands/Regions.py
@@ -1,71 +1,33 @@
-from typing import List, TypedDict
+import logging
+from typing import List
 from BaseClasses import Entrance, MultiWorld, Region
-from .Locations import LocationData, StacklandsLocation, locations_table, lookup_name_to_id as locations_lookup_name_to_id
+from .Locations import StacklandsLocation, location_table
 from .Options import StacklandsOptions
 
-class RegionData(TypedDict):
-    name: str
-    exits: List[str]
-
-# Regions
-regions_table: List[RegionData] = [
-    { "name": "Mainland", "exits": [ "Island" ] },
-    { "name": "Island", "exits": None }
-]
-
 # Create a region
-def create_region(world: MultiWorld, player: int, options: StacklandsOptions, name: str, locations: List[LocationData]=None, exits: List[str]=None):
-    # Create region
+def create_region(world: MultiWorld, player: int, name: str, locations: List[str]=None, exits: List[str]=None) -> Region:
     region = Region(name, player, world)
 
     if locations:
         for location in locations:
-
-            # If goal is 'Kill the Demon', skip the 'Kill the Demon Lord' location
-            if options.goal.value == 0 and location["name"] == "Kill the Demon Lord":
-                continue
-
-            # If pausing is disabled in options, skip pause location
-            if options.pause_enabled.value == False and location["name"] == "Pause using the play icon in the top right corner":
-                continue
-
-            # Create location and add to region
-            loc_id = locations_lookup_name_to_id[location["name"]]
-            loc_obj = StacklandsLocation(player, location["name"], loc_id, region)
-            loc_obj.progress_type = location["classification"]
+            loc_id = location_table[location].code
+            loc_obj = StacklandsLocation(player, location, loc_id, region)
             region.locations.append(loc_obj)
 
     if exits:
-        for ext in exits:
-            region.exits.append(Entrance(player, getConnectionName(name, ext), region))
+        for exit in exits:
+            region.exits.append(Entrance(player, exit, region))
 
     return region
 
 # Create all regions
-def create_all_regions(world: MultiWorld, player: int, options: StacklandsOptions):
+def create_all_regions(world: MultiWorld, player: int):
 
-    # Cycle through regions in json
-    for region in regions_table:
-        locs = [location for location in locations_table if location["region"] == region["name"]]
-        reg_obj = create_region(world, player, options, region["name"], locs, region["exits"])
-        world.regions += [ reg_obj ]
-    
-    # Create default region
-    menu = create_region(world, player, options, "Menu", None, [ "Mainland" ])
-    world.regions += [ menu ]
-    
-    # Connect default region to main
-    menuConn = world.get_entrance("MenuToMainland", player)
-    menuConn.connect(world.get_region("Mainland", player))
-    
-    # Link regions together
-    for region in regions_table:
-        if region["exits"]:
-            for linkedRegion in region["exits"]:
-                connection = world.get_entrance(getConnectionName(region["name"], linkedRegion), player)
-                connection.connect(world.get_region(linkedRegion, player))
+    world.regions += [
+        create_region(world, player, "Menu", None, [ "Start" ]),
+        create_region(world, player, "Mainland", [name for name, loc in location_table.items() if loc.region == "Mainland"])
+    ]
 
-# Get connection name between entrance and exit
-def getConnectionName(ent: str, ext: str):
-    return ent + "To" + ext
+    # Connect menu region to entrance of mainland
+    world.get_entrance("Start", player).connect(world.get_region("Mainland", player))
         

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -1,8 +1,32 @@
+from typing import List
 from BaseClasses import MultiWorld
+from worlds.AutoWorld import LogicMixin
 from worlds.generic.Rules import set_rule
 
+class StacklandsLogic(LogicMixin):
+
+    # Check if player has received booster pack
+    def sl_has_idea(self, name: str, player: int) -> bool:
+        return self.has("Idea: " + name, player)
+    
+    def sl_has_all_ideas(self, ideas: List[str], player: int) -> bool:
+        return self.has_all(set(["Idea: " + idea for idea in ideas]), player)
+    
+    def sl_has_any_ideas(self, ideas: List[str], player: int) -> bool:
+        return self.has_any(set(["Idea: " + idea for idea in ideas]), player)
+    
+    def sl_has_pack(self, name: str, player: int) -> bool:
+        return self.has(name + " Booster Pack", player)
+    
+    def sl_has_all_packs(self, packs: List[str], player: int) -> bool:
+        return self.has_all(set([pack + " Booster Pack" for pack in packs]), player)
+    
+    def sl_has_any_packs(self, packs: List[str], player: int) -> bool:
+        return self.has_any(set([pack + " Booster Pack" for pack in packs]), player)
+
+
 # Set all region and location rules
-def set_all_rules(world: MultiWorld, player: int):
+def set_rules(world: MultiWorld, player: int):
       
     # Region checks (to be implemented later)
     region_checks = {
@@ -11,241 +35,47 @@ def set_all_rules(world: MultiWorld, player: int):
     
     ### Mainland Rules ###
 
-    # Coins
-    set_rule(world.get_location("Have 10 Coins", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Have 30 Coins", player),
-             lambda state: state.has("Idea: Coin Chest", player) and
-                           state.can_reach_location("Have 10 Coins", player))
-    
-    set_rule(world.get_location("Have 50 Coins", player),
-             lambda state: state.can_reach_location("Have 30 Coins", player))
+    # Should be Sphere 1(?)
+    set_rule(world.get_location("Open the Booster Pack", player), lambda state: True)
 
-    # Ideas
-    set_rule(world.get_location("Have 5 Ideas", player),
-             lambda state: state.count_group("All Ideas", player) >= 5)
-    
-    set_rule(world.get_location("Have 10 Ideas", player),
-             lambda state: state.count_group("All Ideas", player) >= 10)
-    
-    # Moons
-    set_rule(world.get_location("Reach Moon 6", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Reach Moon 12", player), # Trialling this to help release un-required boosters
-             lambda state: state.has("Seeking Wisdom Booster Pack", player) and
-                           state.can_reach_location("Reach Moon 6", player))
-    
-    set_rule(world.get_location("Buy something from a Travelling Cart", player),
-             lambda state: state.can_reach_location("Reach Moon 12", player))
-    
-    set_rule(world.get_location("Reach Moon 24", player), # Trialling this to help release un-required boosters
-             lambda state: state.has("Logic and Reason Booster Pack", player) and
-                           state.can_reach_location("Reach Moon 12", player)) 
-    
-    set_rule(world.get_location("Reach Moon 36", player), # Trialling this to help release un-required boosters
-             lambda state: state.has("Order and Structure Booster Pack", player) and
-                           state.can_reach_location("Reach Moon 24", player))
-    
-    # Miscellaneous
-    set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
-             lambda state: world.worlds[player].options.basic_pack.value == True or 
-                           state.has("Humble Beginnings Booster Pack", player))
+    # Should be Sphere 2(?)
+    set_rule(world.get_location("Make a Stick from Wood", player), lambda state: state.sl_has_idea("Stick", player))
 
-    set_rule(world.get_location("Sell a Card at a Market", player),
-             lambda state: state.has_all(set(["Idea: Market", "Idea: Brick", "Idea: Plank"]), player))
+    # Should be Sphere 3(?)
+    set_rule(world.get_location("Start a Campfire", player), lambda state: state.sl_has_idea("Campfire", player) and state.can_reach_location("Make a Stick from Wood", player))
 
-    # 'Combat' Path
-    set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Kill a Rat", player),
-             lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player))
-    
-    set_rule(world.get_location("Train Militia", player), # Trialling this
-             lambda state: state.has("Explorers Booster Pack", player) and
-                           state.has_any(set(["Idea: Slingshot", "Idea: Spear"]), player) and
-                           state.can_reach_location("Kill a Rat", player))
-    
-    set_rule(world.get_location("Train a Wizard", player), # Trialling this
-             lambda state: state.has("Explorers Booster Pack", player) and
-                           state.has("Idea: Magic Wand", player) and
-                           state.can_reach_location("Kill a Rat", player))
-    
-    set_rule(world.get_location("Have a Villager with Combat Level 20", player),
-             lambda state: state.has("Explorers Booster Pack", player) and
-                           state.can_reach_location("Train Militia", player) and
-                           state.can_reach_location("Train a Wizard", player))
-    
-    set_rule(world.get_location("Kill a Skeleton", player), # Trialling this
-             lambda state: state.has("The Armory Booster Pack", player) and
-                           state.can_reach_location("Have a Villager with Combat Level 20", player))
+    # Should be Sphere 2(?)
+    # set_rule(world.get_location("Make a Stick from Wood", player), lambda state: state.has("Idea: Stick", player))
+    # set_rule(world.get_location("Start a Campfire", player), lambda state: state.has_all(set(["Idea: Stick", "Idea: Campfire"]), player))
+    # set_rule(world.get_location("Task 1", player), lambda state: state.has_all(set(["Idea: Stick", "Idea: Campfire"]), player))
 
-    set_rule(world.get_location("Train a Ninja", player), # Trialling this
-             lambda state: state.has("Idea: Throwing Stars", player) and
-                           state.can_reach_location("Build a Smithy", player) and
-                           state.can_reach_location("Have a Villager with Combat Level 20", player))
+    # set_rule(world.get_location("Ability to Build Campfire", player), lambda state: state.sl_has_all_ideas(["Stick", "Campfire"], player))
 
-    # 'Cooking' Path
-    set_rule(world.get_location("Make a Stick from Wood", player),
-             lambda state: state.has("Idea: Stick", player) and
-                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Start a Campfire", player),
-             lambda state: state.has("Idea: Campfire", player) and
-                           state.can_reach_location("Make a Stick from Wood", player))
-    
-    set_rule(world.get_location("Cook Raw Meat", player),
-             lambda state: state.has_all(set(["Idea: Cooked Meat", "Reap and Sow Booster Pack"]), player) and
-                           state.can_reach_location("Start a Campfire", player))
-    
-    set_rule(world.get_location("Cook an Omelette", player),
-             lambda state: state.has("Idea: Omelette", player) and
-                           state.can_reach_location("Cook Raw Meat", player))
-    
-    set_rule(world.get_location("Cook a Frittata", player),
-             lambda state: state.has_all(set(["Idea: Frittata", "Idea: Stove", "Curious Cuisine Booster Pack"]), player) and
-                           state.can_reach_location("Cook an Omelette", player))
-    
-    # 'Exploring' Path
-    set_rule(world.get_location("Find a Graveyard", player),
-             lambda state: state.has("Explorers Booster Pack", player) and
-                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Find the Catacombs", player),
-             lambda state: state.can_reach_location("Find a Graveyard", player)) # <- Can be Found from Graveyard
+    # Should be Sphere 3(?)
+    # set_rule(world.get_location("Task 1", player), lambda state: state.has("Campfire", player))
+    # set_rule(world.get_location("Task 2", player), lambda state: state.has("Campfire", player))
+    # set_rule(world.get_location("Build a Sawmill", player), lambda state: state.has("Campfire", player) and state.has_all(set(["Idea: Sawmill", "Idea: Plank"]), player))
 
-    set_rule(world.get_location("Open a Treasure Chest", player),
-             lambda state: state.can_reach_location("Find the Catacombs", player))
+    # set_rule(world.get_location("Ability to Build Sawmill", player), lambda state: state.has("Campfire", player) and state.sl_has_all_ideas(["Sawmill", "Plank"], player))
     
-    set_rule(world.get_location("Find a mysterious artifact", player), # <- Minimum Requirement for Goal Path
-             lambda state: state.can_reach_location("Open a Treasure Chest", player))
-    
-    set_rule(world.get_location("Get a Dog", player),
-             lambda state: state.can_reach_location("Open a Treasure Chest", player))
-    
-    set_rule(world.get_location("Train an Explorer", player),
-             lambda state: state.can_reach_location("Open a Treasure Chest", player))
-    
-    set_rule(world.get_location("Explore a Forest", player),
-             lambda state: state.can_reach_location("Open a Treasure Chest", player))
-    
-    set_rule(world.get_location("Explore a Mountain", player),
-             lambda state: state.can_reach_location("Open a Treasure Chest", player))
-    
-    # 'Farming' Path
-    set_rule(world.get_location("Have 5 Food", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Grow a Berry Bush using Soil", player),
-             lambda state: state.has("Idea: Growth", player) and
-                           state.can_reach_location("Have 5 Food", player))
-    
-    set_rule(world.get_location("Have 10 Food", player),
-             lambda state: state.can_reach_location("Grow a Berry Bush using Soil", player))
+    # Should be Sphere 4(?)
+    # set_rule(world.get_location("Task 3", player), lambda state: lambda state: state.has("Sawmill", player))
+    # set_rule(world.get_location("Task 4", player), lambda state: lambda state: state.has("Sawmill", player))
+    # set_rule(world.get_location("Task 5", player), lambda state: lambda state: state.has("Sawmill", player))
+    # set_rule(world.get_location("Build a Smelter", player), lambda state: state.has("Sawmill", player) and state.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Iron Bar"]), player))
 
-    set_rule(world.get_location("Build a Shed", player),
-             lambda state: state.has("Idea: Shed", player) and
-                           state.can_reach_location("Have 10 Food", player))
+    # set_rule(world.get_location("Ability to Build Smelter", player), lambda state: state.has("Sawmill", player) and state.sl_has_all_ideas(["Smelter", "Brick", "Iron Bar"], player))
+    
+    # Should be Sphere 4(?)
+    set_rule(world.get_location("Bring the Goblet to the Temple", player), lambda state: state.can_reach_location("Start a Campfire", player))
 
-    set_rule(world.get_location("Have 20 Food", player),
-             lambda state: state.can_reach_location("Build a Shed", player))
+    # set_rule(world.get_location("Bring the Goblet to the Temple", player), 
+    #          lambda state: state.can_reach_location("Start a Capfire", player) and
+    #                        state.can_reach_location("Build a Sawmill", player) and
+    #                        state.can_reach_location("Build a Smelter", player))
+    # set_rule(world.get_location("Bring the Goblet to the Temple", player), lambda state: state.has_all(set(["Campfire", "Sawmill", "Smelter"]), player))
+    
+    set_rule(world.get_location("Defeat Boss", player), lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
 
-    set_rule(world.get_location("Build a Garden", player), # <- Minimum requirement for Goal Path
-             lambda state: state.has("Idea: Garden", player) and
-                           state.can_reach_location("Have 20 Food", player))
-    
-    set_rule(world.get_location("Build a Farm", player),
-             lambda state: state.has_all(set(["Idea: Farm", "Idea: Brick", "Idea: Plank"]), player) and
-                           state.can_reach_location("Build a Garden", player))
-    
-    set_rule(world.get_location("Have 50 Food", player),
-             lambda state: state.can_reach_location("Build a Farm", player))
-    
-    # 'Metal' Path
-    set_rule(world.get_location("Build a Mine", player),
-             lambda state: state.has("Idea: Iron Mine", player) and
-                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Build a Smelter", player),
-             lambda state: state.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Plank"]), player) and
-                           state.can_reach_location("Build a Mine", player))
-    
-    set_rule(world.get_location("Get an Iron Bar", player),
-             lambda state: state.has("Idea: Iron Bar", player) and
-                           state.can_reach_location("Build a Smelter", player))
-    
-    set_rule(world.get_location("Build a Smithy", player),
-             lambda state: state.has("Idea: Smithy", player) and
-                           state.can_reach_location("Get an Iron Bar", player))
-    
-    # 'Stone' Path
-    set_rule(world.get_location("Have 10 Stone", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Build a Quarry", player),
-             lambda state: state.has_all(set(["Idea: Quarry", "Idea: Brick"]), player) and
-                           state.can_reach_location("Have 10 Stone", player))
-    
-    set_rule(world.get_location("Build a Brickyard", player),
-             lambda state: state.has("Idea: Brickyard", player) and
-                           state.can_reach_location("Get an Iron Bar", player) and
-                           state.can_reach_location("Build a Quarry", player))
-
-    # 'Villager' Path
-    set_rule(world.get_location("Get a Second Villager", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-
-    set_rule(world.get_location("Build a House", player),
-             lambda state: state.has("Idea: House", player) 
-                           and state.can_reach_location("Get a Second Villager", player))
-    
-    set_rule(world.get_location("Have 3 Houses", player),
-             lambda state: state.can_reach_location("Build a House", player))
-    
-    set_rule(world.get_location("Create Offspring", player),
-             lambda state: state.has("Idea: Offspring", player) 
-                           and state.can_reach_location("Build a House", player))
-    
-    set_rule(world.get_location("Get 3 Villagers", player),
-             lambda state: state.can_reach_location("Create Offspring", player))
-
-    # 'Wood' Path
-    set_rule(world.get_location("Harvest a Tree using a Villager", player),
-             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
-    
-    set_rule(world.get_location("Have 10 Wood", player),
-             lambda state: state.can_reach_location("Harvest a Tree using a Villager", player))
-    
-    set_rule(world.get_location("Build a Lumber Camp", player),
-             lambda state: state.has_all(set(["Idea: Lumber Camp", "Idea: Plank"]), player) and
-                           state.can_reach_location("Have 10 Wood", player))
-    
-    set_rule(world.get_location("Build a Sawmill", player),
-             lambda state: state.has("Idea: Sawmill", player) and
-                           state.can_reach_location("Get an Iron Bar", player) and
-                           state.can_reach_location("Build a Lumber Camp", player))
-    
-    # 'Goal' Path (Other paths converge here)
-    set_rule(world.get_location("Build a Temple", player), # Trialling this
-             lambda state: state.has("Idea: Temple", player) and
-                           state.can_reach_location("Get 3 Villagers", player) and # <- 'House' is included as part of this path
-                           state.can_reach_location("Get an Iron Bar", player) and # <- 'Smelter' is included as part of this path
-                           state.can_reach_location("Build a Quarry", player) and # <- 'Brick' is included as part of this path
-                           state.can_reach_location("Build a Lumber Camp", player)) # <- 'Plank' is included as part of this path
-    
-    set_rule(world.get_location("Bring the Goblet to the Temple", player), # Trialling this
-             lambda state: state.can_reach_location("Build a Temple", player) and
-                           state.can_reach_location("Cook Raw Meat", player) and # <- 'Campfire' is included as part of this path
-                           state.can_reach_location("Kill a Skeleton", player) and
-                           state.can_reach_location("Build a Garden", player) and # <- 'Shed' is included as part of this path
-                           state.can_reach_location("Find a mysterious artifact", player))
-    
-    set_rule(world.get_location("Kill the Demon", player),
-             lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
-    
-    # Include this rule if demon lord is the goal
-    if world.worlds[player].options.goal == 1:
-        set_rule(world.get_location("Kill the Demon Lord", player),
-                lambda state: state.can_reach_location("Kill the Demon", player))
+    # Completion event
+    world.completion_condition[player] = lambda state: state.has("Victory", player)

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -32,50 +32,259 @@ def set_rules(world: MultiWorld, player: int):
     region_checks = {
         "Mainland": lambda state: True
     }
-    
-    ### Mainland Rules ###
 
-    # Should be Sphere 1(?)
+    # Get relevant options
+    goal = world.worlds[player].options.goal.value
+    pause_enabled = world.worlds[player].options.pause_enabled.value
+
+    # Amounts
+    set_rule(world.get_location("Have 10 Coins", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Have 30 Coins", player),
+             lambda state: state.sl_has_idea("Coin Chest", player) and # <- Shed for helping with storage space >= 30 Coins
+                           state.can_reach_location("Have 10 Coins", player))
+    
+    set_rule(world.get_location("Have 50 Coins", player), 
+             lambda state: state.can_reach_location("Have 30 Coins", player))
+
+    set_rule(world.get_location("Have 5 Food", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Have 10 Food", player),
+             lambda state: state.can_reach_location("Have 5 Food", player))
+    
+    set_rule(world.get_location("Have 20 Food", player),
+             lambda state: state.can_reach_location("Build a Shed", player) and # <- Shed for helping with storage space >= 20 food
+                           state.can_reach_location("Have 10 Food", player))
+    
+    set_rule(world.get_location("Have 50 Food", player),
+             lambda state: state.can_reach_location("Have 20 Food", player))
+    
+    set_rule(world.get_location("Have 3 Houses", player),
+             lambda state: state.can_reach_location("Build a House", player))
+    
+    set_rule(world.get_location("Have 5 Ideas", player),
+             lambda state: state.count_group("All Ideas", player) >= 5)
+    
+    set_rule(world.get_location("Have 10 Ideas", player),
+             lambda state: state.count_group("All Ideas", player) >= 10)
+    
+    set_rule(world.get_location("Have 10 Stone", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Have 10 Wood", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    # Durations
+    set_rule(world.get_location("Reach Moon 6", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Reach Moon 12", player),
+             lambda state: state.sl_has_pack("Seeking Wisdom", player) and # <- Trialling to help increase chance of unrequired pack drops
+                           state.can_reach_location("Reach Moon 6", player))
+    
+    set_rule(world.get_location("Reach Moon 24", player),
+             lambda state: state.sl_has_pack("Logic and Reason", player) and # <- Trialling to help increase chance of unrequired pack drops
+                           state.can_reach_location("Reach Moon 12", player))
+    
+    set_rule(world.get_location("Reach Moon 24", player),
+             lambda state: state.can_reach_location("Reach Moon 36", player)) # <- Trialling to help increase chance of unrequired pack drops
+
+    # Miscellaneous
+    set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
+             lambda state: state.sl_has_pack("Humble Beginnings", player))
+    
+    set_rule(world.get_location("Sell a Card at a Market", player),
+             lambda state: state.sl_has_all_ideas(["Market", "Brick", "Plank"], player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    
+    
+    # 'Starting' Path - Quests that can be achieved immediately
     set_rule(world.get_location("Open the Booster Pack", player), lambda state: True)
-
-    # Should be Sphere 2(?)
-    set_rule(world.get_location("Make a Stick from Wood", player), lambda state: state.sl_has_idea("Stick", player))
-
-    # Should be Sphere 3(?)
-    set_rule(world.get_location("Start a Campfire", player), lambda state: state.sl_has_idea("Campfire", player) and state.can_reach_location("Make a Stick from Wood", player))
-
-    # Should be Sphere 2(?)
-    # set_rule(world.get_location("Make a Stick from Wood", player), lambda state: state.has("Idea: Stick", player))
-    # set_rule(world.get_location("Start a Campfire", player), lambda state: state.has_all(set(["Idea: Stick", "Idea: Campfire"]), player))
-    # set_rule(world.get_location("Task 1", player), lambda state: state.has_all(set(["Idea: Stick", "Idea: Campfire"]), player))
-
-    # set_rule(world.get_location("Ability to Build Campfire", player), lambda state: state.sl_has_all_ideas(["Stick", "Campfire"], player))
-
-    # Should be Sphere 3(?)
-    # set_rule(world.get_location("Task 1", player), lambda state: state.has("Campfire", player))
-    # set_rule(world.get_location("Task 2", player), lambda state: state.has("Campfire", player))
-    # set_rule(world.get_location("Build a Sawmill", player), lambda state: state.has("Campfire", player) and state.has_all(set(["Idea: Sawmill", "Idea: Plank"]), player))
-
-    # set_rule(world.get_location("Ability to Build Sawmill", player), lambda state: state.has("Campfire", player) and state.sl_has_all_ideas(["Sawmill", "Plank"], player))
     
-    # Should be Sphere 4(?)
-    # set_rule(world.get_location("Task 3", player), lambda state: lambda state: state.has("Sawmill", player))
-    # set_rule(world.get_location("Task 4", player), lambda state: lambda state: state.has("Sawmill", player))
-    # set_rule(world.get_location("Task 5", player), lambda state: lambda state: state.has("Sawmill", player))
-    # set_rule(world.get_location("Build a Smelter", player), lambda state: state.has("Sawmill", player) and state.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Iron Bar"]), player))
-
-    # set_rule(world.get_location("Ability to Build Smelter", player), lambda state: state.has("Sawmill", player) and state.sl_has_all_ideas(["Smelter", "Brick", "Iron Bar"], player))
+    set_rule(world.get_location("Drag the Villager on top of the Berry Bush", player), lambda state: True)
     
-    # Should be Sphere 4(?)
-    set_rule(world.get_location("Bring the Goblet to the Temple", player), lambda state: state.can_reach_location("Start a Campfire", player))
-
-    # set_rule(world.get_location("Bring the Goblet to the Temple", player), 
-    #          lambda state: state.can_reach_location("Start a Capfire", player) and
-    #                        state.can_reach_location("Build a Sawmill", player) and
-    #                        state.can_reach_location("Build a Smelter", player))
-    # set_rule(world.get_location("Bring the Goblet to the Temple", player), lambda state: state.has_all(set(["Campfire", "Sawmill", "Smelter"]), player))
+    set_rule(world.get_location("Mine a Rock using a Villager", player), lambda state: True)
     
-    set_rule(world.get_location("Defeat Boss", player), lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
+    set_rule(world.get_location("Sell a Card", player), lambda state: True)
+
+    if pause_enabled: # <- Set location rule only if pausing is enabled
+        set_rule(world.get_location("Pause using the play icon in the top right corner", player),
+                    lambda state: True) 
+
+    # 'Combat' Path
+    set_rule(world.get_location("Train Militia", player),
+             lambda state: state.has_any(set(["Idea: Slingshot", "Idea: Spear"]), player) and
+                           state.sl_has_pack("Explorers", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Train a Wizard", player),
+             lambda state: state.sl_has_idea("Magic Wand", player) and
+                           state.sl_has_pack("Explorers", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Kill a Skeleton", player), # <- Minimum requirement for goal path (trialling this)
+             lambda state: state.sl_has_pack("The Armory", player) and
+                           state.can_reach_location("Train Militia", player) and
+                           state.can_reach_location("Train a Wizard", player))
+    
+    set_rule(world.get_location("Train a Ninja", player), # <- Not required for goal path, but useful
+             lambda state: state.sl_has_idea("Throwing Stars", player) and
+                           state.can_reach_location("Kill a Skeleton", player))
+
+    set_rule(world.get_location("Have a Villager with Combat Level 20", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+
+    set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Kill a Rat", player),  # <- Not required for goal path
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+
+    # 'Cooking' Path
+    set_rule(world.get_location("Make a Stick from Wood", player),
+             lambda state: state.sl_has_idea("Stick", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Start a Campfire", player),
+             lambda state: state.sl_has_idea("Campfire", player) and
+                           state.can_reach_location("Make a Stick from Wood", player))
+    
+    set_rule(world.get_location("Cook Raw Meat", player),
+             lambda state: state.sl_has_idea("Cooked Meat", player) and
+                           state.sl_has_pack("Reap & Sow", player) and # <- To help balance booster pack progression
+                           state.can_reach_location("Start a Campfire", player))
+    
+    set_rule(world.get_location("Cook an Omelette", player), # <- Not required for goal path, but useful to have
+             lambda state: state.sl_has_all_ideas(["Omelette", "Stove"], player) and
+                           state.can_reach_location("Cook Raw Meat", player))
+    
+    set_rule(world.get_location("Cook a Frittata", player), # <- Not required for goal path, but useful to have
+             lambda state: state.sl_has_idea("Frittata", player) and
+                           state.sl_has_pack("Curious Cuisine", player) and # <- To help balance booster pack progression
+                           state.can_reach_location("Cook an Omelette", player))
+    
+    # 'Brick' Path
+    set_rule(world.get_location("Build a Quarry", player),
+             lambda state: state.sl_has_idea("Quarry", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Build a Brickyard", player),
+             lambda state: state.sl_has_idea("Brickyard", player) and
+                           state.can_reach_location("Get an Iron Bar", player) and # <- 'Brick' / 'Iron Bar' / 'Smelter' included in path
+                           state.can_reach_location("Build a Quarry", player))
+    
+    # 'Exploring' Path
+    set_rule(world.get_location("Find a Graveyard", player),
+             lambda state: state.sl_has_all_packs(["Humble Beginnings", "Explorers"], player))
+    
+    set_rule(world.get_location("Find a mysterious artifact", player), # <- Minimum requirement for goal path
+             lambda state: state.can_reach_location("Find a Graveyard", player))
+    
+    set_rule(world.get_location("Find the Catacombs", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Open a Treasure Chest", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Get a Dog", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Train an Explorer", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Explore a Forest", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Explore a Mountain", player), # <- Not required for goal path
+             lambda state: state.can_reach_location("Find a mysterious artifact", player))
+
+    # 'Farming' Path
+    set_rule(world.get_location("Grow a Berry Bush using Soil", player),
+             lambda state: state.sl_has_idea("Growth", player) and
+                           state.can_reach_location("Have 5 Food", player))
+    
+    set_rule(world.get_location("Build a Shed", player),
+             lambda state: state.sl_has_idea("Shed", player) and
+                           state.can_reach_location("Have 5 Food", player))
+    
+    set_rule(world.get_location("Build a Garden", player), # <- Minimum requirement for goal
+             lambda state: state.sl_has_idea("Garden", player) and
+                           state.sl_has_pack("Reap & Sow", player) and # <- To help balance booster pack progression
+                           state.can_reach_location("Build a Shed", player))
+    
+    set_rule(world.get_location("Build a Farm", player), # <- Not required for goal path, but useful to have
+             lambda state: state.sl_has_all_ideas(["Farm", "Brick", "Plank"], player) and
+                           state.can_reach_location("Build a Shed", player))
+
+    # 'Iron Bar' Path
+    set_rule(world.get_location("Build a Smelter", player),
+             lambda state: state.sl_has_all_ideas(["Smelter", "Brick", "Plank"], player) and
+                           state.sl_has_pack("Seeking Wisdom", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Get an Iron Bar", player),
+             lambda state: state.sl_has_idea("Iron Bar", player) and
+                           state.can_reach_location("Build a Smelter", player) and
+                           (state.can_reach_location("Build a Mine", player) or state.sl_has_pack("Order and Structure", player)))
+    
+    set_rule(world.get_location("Build a Smithy", player),
+             lambda state: state.sl_has_idea("Smithy", player) and
+                           state.can_reach_location("Get an Iron Bar", player))
+    
+    set_rule(world.get_location("Build a Mine", player), # <- Not required for goal path, but useful to have
+             lambda state: state.sl_has_idea("Iron Mine", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    # 'Villager' Path
+    set_rule(world.get_location("Get a Second Villager", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Build a House", player),
+             lambda state: state.sl_has_idea("House", player) and state.can_reach_location("Get a Second Villager", player))
+    
+    set_rule(world.get_location("Create Offspring", player),
+             lambda state: state.sl_has_idea("Offspring", player) and state.can_reach_location("Build a House", player))
+    
+    set_rule(world.get_location("Get 3 Villagers", player),
+             lambda state: state.can_reach_location("Create Offspring", player) or state.can_reach_location("Get a Dog", player))
+    
+    # 'Plank' Path
+    set_rule(world.get_location("Harvest a Tree using a Villager", player),
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
+    
+    set_rule(world.get_location("Build a Lumber Camp", player),
+             lambda state: state.sl_has_idea("Lumber Camp", player) and
+                           state.can_reach_location("Harvest a Tree using a Villager", player))
+    
+    set_rule(world.get_location("Build a Sawmill", player), # <- Not required for goal path
+             lambda state: state.sl_has_idea("Sawmill", player) and
+                           state.can_reach_location("Get an Iron Bar", player) and # <- 'Plank' / 'Iron Bar' / 'Smelter' included in path
+                           state.can_reach_location("Build a Lumber Camp", player))
+
+    # 'Goal' Path
+    set_rule(world.get_location("Build a Temple", player), 
+             lambda state: state.sl_has_idea("Temple", player) and
+                           state.can_reach_location("Create Offspring", player) and # <- 'House' is included in this path (and will provide 3x Villagers)
+                           state.can_reach_location("Get an Iron Bar", player)) # <- 'Smelter' / 'Iron Bar' / 'Plank' / 'Brick' are included in this path
+    
+    set_rule(world.get_location("Bring the Goblet to the Temple", player),
+             lambda state: state.can_reach_location("Build a Temple", player) and # <- Able to build the temple
+                           state.can_reach_location("Build a Garden", player) and # <- 'Shed' is included in this path
+                           state.can_reach_location("Cook Raw Meat", player) and # <- 'Stick' / 'Campfire' are included in this path
+                           state.can_reach_location("Find a mysterious artifact", player) and # <- Able to find the goblet
+                           state.can_reach_location("Kill a Skeleton", player)) # <- Access to 'The Armory' for equipment drops
+    
+    set_rule(world.get_location("Kill the Demon", player), lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
+
+    # If goal is 'Kill the Demon Lord' then also set that rule
+    if goal == 1:
+        set_rule(world.get_location("Kill the Demon Lord", player), lambda state: state.can_reach_location("Kill the Demon", player))
+
+    # Set the rule for the victory event
+    set_rule(world.get_location("Complete the Goal", player), lambda state: state.can_reach_location("Kill the Demon", player) if goal == 0 else state.can_reach_location("Kill the Demon Lord", player))
 
     # Completion event
     world.completion_condition[player] = lambda state: state.has("Victory", player)

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -20,204 +20,234 @@ def set_all_rules(world: MultiWorld, player: int):
     }
     
     ### Mainland Rules ###
+
+    # Coins
+    set_rule(world.get_location("Have 10 Coins", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
     
-    # 'Welcome' Category
-    set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
-             lambda state: bool(world.worlds[player].options.basic_pack.value) or state.has("Humble Beginnings Booster Pack", player))
+    set_rule(world.get_location("Have 30 Coins", player),
+             lambda state: state.has("Idea: Coin Chest", player) and
+                           state.can_reach_location("Have 10 Coins", player))
     
+    set_rule(world.get_location("Have 50 Coins", player),
+             lambda state: state.can_reach_location("Have 30 Coins", player))
+
+    # Ideas
+    set_rule(world.get_location("Have 5 Ideas", player),
+             lambda state: state.count_group("Mainland Ideas", player) >= 5)
+    
+    set_rule(world.get_location("Have 10 Ideas", player),
+             lambda state: state.count_group("Mainland Ideas", player) >= 10)
+    
+    # Moons
+    set_rule(world.get_location("Reach Moon 6", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
+    
+    set_rule(world.get_location("Reach Moon 12", player), # Trialling this to help release un-required boosters
+             lambda state: state.has("Seeking Wisdom Booster Pack") and
+                           state.can_reach_location("Reach Moon 6", player))
+    
+    set_rule(world.get_location("Buy something from a Travelling Cart", player),
+             lambda state: state.can_reach_location("Reach Moon 12", player))
+    
+    set_rule(world.get_location("Reach Moon 24", player), # Trialling this to help release un-required boosters
+             lambda state: state.has("Logic and Reason Booster Pack", player) and
+                           state.can_reach_location("Reach Moon 12", player)) 
+    
+    set_rule(world.get_location("Reach Moon 36", player), # Trialling this to help release un-required boosters
+             lambda state: state.has("Order and Structure Booster Pack", player) and
+                           state.can_reach_location("Reach Moon 24", player))
+    
+    # Miscellaneous
+    set_rule(world.get_location("Sell a Card at a Market", player),
+             lambda state: state.has_all(set(["Idea: Market", "Idea: Brick", "Idea: Plank"]), player))
+
+    # 'Combat' Path
+    set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
+    
+    set_rule(world.get_location("Kill a Rat", player),
+             lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player))
+    
+    set_rule(world.get_location("Train Militia", player), # Trialling this
+             lambda state: state.has("Explorers Booster Pack") and
+                           state.has_any(set(["Idea: Slingshot", "Idea: Spear"]), player) and
+                           state.can_reach_location("Kill a Rat", player))
+    
+    set_rule(world.get_location("Train a Wizard", player), # Trialling this
+             lambda state: state.has("Explorers Booster Pack") and
+                           state.has("Idea: Magic Wand", player) and
+                           state.can_reach_location("Kill a Rat", player))
+    
+    set_rule(world.get_location("Have a Villager with Combat Level 20", player),
+             lambda state: state.has("Explorers Booster Pack", player) and
+                           state.can_reach_location("Train Militia", player) and
+                           state.can_reach_location("Train a Wizard", player))
+    
+    set_rule(world.get_location("Kill a Skeleton", player), # Trialling this
+             lambda state: state.has("The Armory Booster Pack", player) and
+                           state.can_reach_location("Have a Villager with Combat Level 20", player))
+
+    set_rule(world.get_location("Train a Ninja", player), # Trialling this
+             lambda state: state.has("Idea: Throwing Stars", player) and
+                           state.can_reach_location("Build a Smithy", player) and
+                           state.can_reach_location("Have a Villager with Combat Level 20", player))
+
+    # 'Cooking' Path
+    set_rule(world.get_location("Make a Stick from Wood", player),
+             lambda state: state.has_all(set(["Idea: Stick", "Humble Beginnings Booster Pack"]), player))
+    
+    set_rule(world.get_location("Start a Campfire", player),
+             lambda state: state.has("Idea: Campfire", player) and
+                           state.can_reach_location("Make a Stick from Wood", player))
+    
+    set_rule(world.get_location("Cook Raw Meat", player),
+             lambda state: state.has_all(set(["Idea: Cooked Meat", "Reap and Sow Booster Pack"]), player) and
+                           state.can_reach_location("Start a Campfire", player))
+    
+    set_rule(world.get_location("Cook an Omelette", player),
+             lambda state: state.has("Idea: Omelette", player) and
+                           state.can_reach_location("Cook Raw Meat", player))
+    
+    set_rule(world.get_location("Cook a Frittata", player),
+             lambda state: state.has_all(set(["Idea: Frittata", "Idea: Stove", "Curious Cuisine Booster Pack"]), player) and
+                           state.can_reach_location("Cook an Omelette", player))
+    
+    # 'Exploring' Path
+    set_rule(world.get_location("Find a Graveyard", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player)) # <- Created with 2x Corpse
+    
+    set_rule(world.get_location("Find the Catacombs", player),
+             lambda state: state.has("Explorers Booster Pack", player) and
+                           state.can_reach_location("Find a Graveyard", player)) # <- Can be Found from Graveyard
+
+    set_rule(world.get_location("Open a Treasure Chest", player),
+             lambda state: state.can_reach_location("Find the Catacombs", player))
+    
+    set_rule(world.get_location("Find a mysterious artifact", player), # <- Minimum Requirement for Goal Path
+             lambda state: state.can_reach_location("Open a Treasure Chest", player))
+    
+    set_rule(world.get_location("Get a Dog", player),
+             lambda state: state.can_reach_location("Open a Treasure Chest", player))
+    
+    set_rule(world.get_location("Train an Explorer", player),
+             lambda state: state.can_reach_location("Open a Treasure Chest", player))
+    
+    set_rule(world.get_location("Explore a Forest", player),
+             lambda state: state.can_reach_location("Open a Treasure Chest", player))
+    
+    set_rule(world.get_location("Explore a Mountain", player),
+             lambda state: state.can_reach_location("Open a Treasure Chest", player))
+    
+    # 'Farming' Path
+    set_rule(world.get_location("Have 5 Food", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
+    
+    set_rule(world.get_location("Grow a Berry Bush using Soil", player),
+             lambda state: state.has("Idea: Growth", player) and
+                           state.can_reach_location("Have 5 Food", player))
+    
+    set_rule(world.get_location("Have 10 Food", player),
+             lambda state: state.can_reach_location("Grow a Berry Bush using Soil", player))
+
+    set_rule(world.get_location("Build a Shed", player),
+             lambda state: state.has("Idea: Shed", player) and
+                           state.can_reach_location("Have 10 Food", player))
+
+    set_rule(world.get_location("Have 20 Food", player),
+             lambda state: state.can_reach_location("Build a Shed", player))
+
+    set_rule(world.get_location("Build a Garden", player), # <- Minimum requirement for Goal Path
+             lambda state: state.has("Idea: Garden", player) and
+                           state.can_reach_location("Have 20 Food", player))
+    
+    set_rule(world.get_location("Build a Farm", player),
+             lambda state: state.has_all(set(["Idea: Farm", "Idea: Brick", "Idea: Plank"]), player) and
+                           state.can_reach_location("Build a Garden", player))
+    
+    set_rule(world.get_location("Have 50 Food", player),
+             lambda state: state.can_reach_location("Build a Farm", player))
+    
+    # 'Metal' Path
+    set_rule(world.get_location("Build a Mine", player),
+             lambda state: state.has_all(set(["Idea: Iron Mine", "Humble Beginnings Booster Pack"]), player))
+    
+    set_rule(world.get_location("Build a Smelter", player),
+             lambda state: state.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Plank"]), player) and
+                           state.can_reach_location("Build a Mine", player))
+    
+    set_rule(world.get_location("Get an Iron Bar", player),
+             lambda state: state.has("Idea: Iron Bar", player) and
+                           state.can_reach_location("Build a Smelter", player))
+    
+    set_rule(world.get_location("Build a Smithy", player),
+             lambda state: state.has("Idea: Smithy", player) and
+                           state.can_reach_location("Get an Iron Bar", player))
+    
+    # 'Stone' Path
+    set_rule(world.get_location("Have 10 Stone", player),
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
+    
+    set_rule(world.get_location("Build a Quarry", player),
+             lambda state: state.has_all(set(["Idea: Quarry", "Idea: Brick"]), player) and
+                           state.can_reach_location("Have 10 Stone", player))
+    
+    set_rule(world.get_location("Build a Brickyard", player),
+             lambda state: state.has("Idea: Brickyard", player) and
+                           state.can_reach_location("Get an Iron Bar", player) and
+                           state.can_reach_location("Build a Quarry", player))
+
+    # 'Villager' Path
+    set_rule(world.get_location("Get a Second Villager", player),
+             lambda state: state.has("Humble Beginnings Boster Pack")) # <- Second villager obtained from humble beginnings
+
+    set_rule(world.get_location("Build a House", player),
+             lambda state: state.has("Idea: House", player) 
+                           and state.can_reach_location("Get a Second Villager", player))
+    
+    set_rule(world.get_location("Have 3 Houses", player),
+             lambda state: state.can_reach_location("Build a House", player))
+    
+    set_rule(world.get_location("Create Offspring", player),
+             lambda state: state.has("Idea: Offspring", player) 
+                           and state.can_reach_location("Build a House", player))
+    
+    set_rule(world.get_location("Get 3 Villagers", player),
+             lambda state: state.can_reach_location("Create Offspring", player))
+
+    # 'Wood' Path
     set_rule(world.get_location("Harvest a Tree using a Villager", player),
              lambda state: state.stacklands_access_humble_beginnings(player))
     
-    set_rule(world.get_location("Make a Stick from Wood", player),
-             lambda state: state.has("Idea: Stick", player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Grow a Berry Bush using Soil", player),
-             lambda state: state.has("Idea: Growth", player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Build a House", player),
-             lambda state: state.has("Idea: House", player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Get a Second Villager", player),
-             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Second villager is received from humble beginnings
-    
-    set_rule(world.get_location("Create Offspring", player),
-             lambda state: state.has("Idea: Offspring", player) and state.can_reach_location("Build a House", player)) # <- Need a house to make offspring
-    
-    # 'The Grand Scheme' Category    
-    set_rule(world.get_location("Get 3 Villagers", player),
-             lambda state: state.can_reach_location("Create Offspring", player) or state.can_reach_location("Get a Dog", player)) # <- Third villager can be from offspring or a dog
-    
-    set_rule(world.get_location("Find the Catacombs", player),
-             lambda state: state.can_reach_location("Get a Second Villager", player) # <- Catacombs can be retrieved from Graveyard (2x Corpses)
-                           or (state.stacklands_access_humble_beginnings(player) and state.has("Explorers Booster Pack", player))) # <- Catacombs can be found from Explorers pack
-    
-    set_rule(world.get_location("Find a mysterious artifact", player),
-             lambda state: state.can_reach_location("Find the Catacombs", player) # <- Goblet can be retrieved from Catacombs
-                           or state.stacklands_access_humble_beginnings(player)) # <- or from travelling cart
-    
-    set_rule(world.get_location("Build a Temple", player),
-             lambda state: state.has_all(set(["Idea: Temple", "Idea: Plank", "Idea: Brick"]), player) # <- Ideas required
-                           and state.can_reach_location("Get an Iron Bar", player) # <- Need to be able to create iron bars
-                           and state.can_reach_location("Create Offspring", player)) # <- 3x Villagers Needed
-    
-    set_rule(world.get_location("Bring the Goblet to the Temple", player),
-             lambda state: state.can_reach_location("Find a mysterious artifact", player) # <- Goblet required
-                           and state.can_reach_location("Build a Temple", player)) # <- Temple required
-    
-    set_rule(world.get_location("Find a mysterious artifact", player),
-             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Goblet can be found in Catacombs or from travelling cart
-    
-    set_rule(world.get_location("Kill the Demon", player),
-             lambda state: state.can_reach_location("Bring the Goblet to the Temple", player)) # <- Goblet and Temple required
-    
-    # 'The Dark Forest' Category 
-    # To be added, potentially...
-    
-    # 'Power & Skill' Category
-    set_rule(world.get_location("Train Militia", player),
-             lambda state: (state.has("Idea: Spear", player) and state.can_reach_location("Make a Stick from Wood", player)) # <- Self-craft the spear 
-                           or state.stacklands_access_enemies(player)) # <- Get weapons from enemy drop
-
-    set_rule(world.get_location("Kill a Rat", player),
-             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Rats can drop from Humble Beginnings / Strange Portal
-    
-    set_rule(world.get_location("Kill a Skeleton", player),
-             lambda state: state.can_reach_location("Find the Catacombs", player) or state.stacklands_access_enemies(player)) # Skeletons from enemy packs or catacombs / graveyard / strange portal
-    
-    # 'Strengthen Up' Category
-    set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Build a Smithy", player),
-             lambda state: state.has("Idea: Smithy", player) and state.can_reach_location("Get an Iron Bar", player))
-    
-    set_rule(world.get_location("Train a Wizard", player),
-             lambda state: (state.has("Idea: Magic Wand", player) and state.can_reach_location("Make a Stick from Wood", player))
-                           or state.stacklands_access_enemies(player))
-    
-    set_rule(world.get_location("Have a Villager with Combat Level 20", player), 
-             lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player)
-                           and (state.can_reach_location("Train Militia", player) or state.can_reach_location("Train a Wizard", player))
-                           or state.stacklands_access_enemies(player))
-    
-    set_rule(world.get_location("Train a Ninja", player),
-             lambda state: state.has("Idea: Throwing Stars", player) 
-                           and state.can_reach_location("Get an Iron Bar", player) # <- Needed for recipe
-                           and state.can_reach_location("Build a Smithy", player)) # <- Needed for recipe
-    
-    # 'Potluck' Category
-    set_rule(world.get_location("Start a Campfire", player),
-             lambda state: state.has("Idea: Campfire", player) and state.can_reach_location("Make a Stick from Wood", player))
-    
-    set_rule(world.get_location("Cook Raw Meat", player),
-             lambda state: state.has("Idea: Cooked Meat", player) and state.can_reach_location("Start a Campfire", player))
-    
-    set_rule(world.get_location("Cook an Omelette", player),
-             lambda state: state.has("Idea: Omelette", player)
-                           and state.has_any(set(["Reap & Sow Booster Pack", "Curious Cuisine Booster Pack"]), player) # Can get eggs from either pack
-                           and state.can_reach_location("Start a Campfire", player))
-    
-    set_rule(world.get_location("Cook a Frittata", player),
-             lambda state: state.has("Idea: Frittata", player)
-                           and state.has("Curious Cuisine Booster Pack", player) # <- Potatoes and Eggs can both come from this pack
-                           and state.can_reach_location("Start a Campfire", player)) # <- Needed for recipe
-    
-    # 'Discovery' Category
-    set_rule(world.get_location("Explore a Forest", player),
-             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Explore a Mountain", player),
-             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_humble_beginnings(player))
-             
-    set_rule(world.get_location("Open a Treasure Chest", player),
-             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Can get early from travelling cart / graveyard / catacombs
-             
-    set_rule(world.get_location("Find a Graveyard", player),
-             lambda state: state.can_reach_location("Get a Second Villager", player)) # <- Graveyard can be made with 2x corpses
-             
-    set_rule(world.get_location("Get a Dog", player),
-             lambda state: state.can_reach_location("Find the Catacombs", player)  # <- Wolf can be found in catacombs / strange portal
-                           or state.stacklands_access_enemies(player)) # <- Wolf can be found in enemy packs
-             
-    set_rule(world.get_location("Train an Explorer", player),
-             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Map can be found from Travelling Cart / Old Tome
-             
-    # 'Ways and Means' Category
-    set_rule(world.get_location("Have 5 Ideas", player),
-             lambda state: state.stacklands_access_humble_beginnings(player) and state.count_group("All Ideas", player) >= 5)
-    
-    set_rule(world.get_location("Have 10 Ideas", player),
-             lambda state: state.stacklands_access_humble_beginnings(player) and state.count_group("All Ideas", player) >= 10)
-    
     set_rule(world.get_location("Have 10 Wood", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
-             
-    set_rule(world.get_location("Have 10 Stone", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
-             
-    set_rule(world.get_location("Get an Iron Bar", player),
-             lambda state: state.has("Idea: Iron Bar", player) 
-                           and state.can_reach_location("Build a Smelter", player)
-                           and (state.can_reach_location("Build a Mine", player) or state.has_any(set(["Logic and Reason Booster Pack", "Order and Structure Booster Pack"]), player)))
-             
-    set_rule(world.get_location("Have 5 Food", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
-             
-    set_rule(world.get_location("Have 10 Food", player),
-             lambda state: state.can_reach_location("Have 5 Food", player))
-             
-    set_rule(world.get_location("Have 20 Food", player),
-             lambda state: state.can_reach_location("Have 10 Food", player)
-                           and (state.can_reach_location("Build a Shed", player) # <- Player can build shed to allow more basic food on the board
-                           or (state.stacklands_access_humble_beginnings(player) and state.has("Curious Cuisine Booster Pack", player)))) # <- Or player has access to better foods
-             
-    set_rule(world.get_location("Have 50 Food", player), 
-             lambda state: state.can_reach_location("Have 20 Food", player)) # <- If player can gather 20, they should be able to gather 50
-             
-    # 'Construction' Category
-    set_rule(world.get_location("Have 3 Houses", player),
-             lambda state: state.can_reach_location("Build a House", player))
-             
-    set_rule(world.get_location("Build a Shed", player),
-             lambda state: state.has("Idea: Shed", player) and state.can_reach_location("Make a Stick from Wood", player))
-             
-    set_rule(world.get_location("Build a Quarry", player),
-             lambda state: state.has("Idea: Quarry", player) and state.stacklands_access_humble_beginnings(player))
+             lambda state: state.can_reach_location("Harvest a Tree using a Villager", player))
     
     set_rule(world.get_location("Build a Lumber Camp", player),
-             lambda state: state.has("Idea: Lumber Camp", player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Build a Farm", player),
-             lambda state: state.has_all(set(["Idea: Farm", "Idea: Brick", "Idea: Plank"]), player) and state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Build a Brickyard", player),
-             lambda state: state.has_all(set(["Idea: Brickyard", "Idea: Brick"]), player) and state.can_reach_location("Get an Iron Bar", player))
-    
-    set_rule(world.get_location("Sell a Card at a Market", player),
-             lambda state: state.has("Idea: Market", player) and state.stacklands_access_humble_beginnings(player))
-    
-    # 'Longevity' Category
-    set_rule(world.get_location("Reach Moon 6", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
-    
-    set_rule(world.get_location("Reach Moon 12", player),
-             lambda state: state.can_reach_location("Reach Moon 6", player))
-    
-    set_rule(world.get_location("Reach Moon 24", player),
-             lambda state: state.can_reach_location("Reach Moon 12", player))
-             
-    set_rule(world.get_location("Reach Moon 36", player),
-             lambda state: state.can_reach_location("Reach Moon 24", player))
-    
-    # 'Side Quests' Category
-    set_rule(world.get_location("Build a Garden", player),
-             lambda state: state.has("Idea: Garden", player) and state.can_reach_location("Grow a Berry Bush using Soil", player))
+             lambda state: state.has_all(set(["Idea: Lumber Camp", "Idea: Plank"]), player) and
+                           state.can_reach_location("Have 10 Wood", player))
     
     set_rule(world.get_location("Build a Sawmill", player),
-             lambda state: state.has_all(set(["Idea: Sawmill", "Idea: Plank"]), player) and state.stacklands_access_humble_beginnings(player))
+             lambda state: state.has("Idea: Sawmill", player) and
+                           state.can_reach_location("Get an Iron Bar", player) and
+                           state.can_reach_location("Build a Lumber Camp", player))
     
-    set_rule(world.get_location("Build a Mine", player),
-             lambda state: state.has("Idea: Iron Mine", player) and state.stacklands_access_humble_beginnings(player))
+    # 'Goal' Path (Other paths converge here)
+    set_rule(world.get_location("Build a Temple", player), # Trialling this
+             lambda state: state.has("Idea: Temple") and
+                           state.can_reach_location("Get 3 Villagers", player) and # <- 'House' is included as part of this path
+                           state.can_reach_location("Get an Iron Bar", player) and # <- 'Smelter' is included as part of this path
+                           state.can_reach_location("Build a Quarry", player) and # <- 'Brick' is included as part of this path
+                           state.can_reach_location("Build a Lumber Camp", player)) # <- 'Plank' is included as part of this path
     
-    set_rule(world.get_location("Build a Smelter", player),
-             lambda state: state.has_all(set(["Idea: Smelter", "Idea: Brick"]), player) and state.stacklands_access_humble_beginnings(player))
+    set_rule(world.get_location("Bring the Goblet to the Temple", player), # Trialling this
+             lambda state: state.can_reach_location("Build a Temple", player) and
+                           state.can_reach_location("Cook Raw Meat", player) and # <- 'Campfire' is included as part of this path
+                           state.can_reach_location("Kill a Skeleton", player) and
+                           state.can_reach_location("Build a Garden", player) and # <- 'Shed' is included as part of this path
+                           state.can_reach_location("Find a mysterious artifact", player))
+    
+    set_rule(world.get_location("Kill the Demon", player),
+             lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
+    
+    set_rule(world.get_location("Kill the Demon Lord", player),
+             lambda state: state.can_reach_location("Kill the Demon", player))

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -5,7 +5,7 @@ from worlds.generic.Rules import set_rule
 class StacklandsLogic(LogicMixin):
 
     def stacklands_access_enemies(self, player: int) -> bool:
-        return self.stacklands_access_humble_beginnings(player) and self.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"], player))
+        return self.stacklands_access_humble_beginnings(player) and self.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player)
 
     def stacklands_access_humble_beginnings(self, player: int) -> bool:
         return self.can_reach_location("Buy the Humble Beginnings Pack", player)
@@ -23,7 +23,7 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Welcome' Category
     set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: bool(world.worlds[player].options.basic_pack.value) or state.has("Humble Beginnings Booster Pack", player))
     
     set_rule(world.get_location("Harvest a Tree using a Villager", player),
              lambda state: state.stacklands_access_humble_beginnings(player))
@@ -76,29 +76,29 @@ def set_all_rules(world: MultiWorld, player: int):
     # 'Power & Skill' Category
     set_rule(world.get_location("Train Militia", player),
              lambda state: (state.has("Idea: Spear", player) and state.can_reach_location("Make a Stick from Wood", player)) # <- Self-craft the spear 
-                           or state.stacklands_access_to_enemies(player)) # <- Get weapons from enemy drop
+                           or state.stacklands_access_enemies(player)) # <- Get weapons from enemy drop
 
     set_rule(world.get_location("Kill a Rat", player),
-             lambda state: state.stacklands_access_to_humble_beginnings(player)) # <- Rats can drop from Humble Beginnings / Strange Portal
+             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Rats can drop from Humble Beginnings / Strange Portal
     
     set_rule(world.get_location("Kill a Skeleton", player),
-             lambda state: state.can_reach_location("Find the Catacombs", player) or state.stacklands_access_to_enemies(player)) # Skeletons from enemy packs or catacombs / graveyard / strange portal
+             lambda state: state.can_reach_location("Find the Catacombs", player) or state.stacklands_access_enemies(player)) # Skeletons from enemy packs or catacombs / graveyard / strange portal
     
     # 'Strengthen Up' Category
     set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
-             lambda state: state.stacklands_access_to_humble_beginnings(player))
+             lambda state: state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Build a Smithy", player),
              lambda state: state.has("Idea: Smithy", player) and state.can_reach_location("Get an Iron Bar", player))
     
     set_rule(world.get_location("Train a Wizard", player),
              lambda state: (state.has("Idea: Magic Wand", player) and state.can_reach_location("Make a Stick from Wood", player))
-                           or state.stacklands_access_to_enemies(player))
+                           or state.stacklands_access_enemies(player))
     
     set_rule(world.get_location("Have a Villager with Combat Level 20", player), 
              lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player)
                            and (state.can_reach_location("Train Militia", player) or state.can_reach_location("Train a Wizard", player))
-                           or state.stacklands_access_to_enemies(player))
+                           or state.stacklands_access_enemies(player))
     
     set_rule(world.get_location("Train a Ninja", player),
              lambda state: state.has("Idea: Throwing Stars", player) 
@@ -130,30 +130,30 @@ def set_all_rules(world: MultiWorld, player: int):
              lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_humble_beginnings(player))
              
     set_rule(world.get_location("Open a Treasure Chest", player),
-             lambda state: state.stacklands_access_to_basic_pack(player)) # <- Can get early from travelling cart / graveyard / catacombs
+             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Can get early from travelling cart / graveyard / catacombs
              
     set_rule(world.get_location("Find a Graveyard", player),
              lambda state: state.can_reach_location("Get a Second Villager", player)) # <- Graveyard can be made with 2x corpses
              
     set_rule(world.get_location("Get a Dog", player),
              lambda state: state.can_reach_location("Find the Catacombs", player)  # <- Wolf can be found in catacombs / strange portal
-                           or state.stacklands_access_to_enemies(player)) # <- Wolf can be found in enemy packs
+                           or state.stacklands_access_enemies(player)) # <- Wolf can be found in enemy packs
              
     set_rule(world.get_location("Train an Explorer", player),
-             lambda state: state.stacklands_access_to_basic_pack(player)) # <- Map can be found from Travelling Cart / Old Tome
+             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Map can be found from Travelling Cart / Old Tome
              
     # 'Ways and Means' Category
     set_rule(world.get_location("Have 5 Ideas", player),
-             lambda state: state.stacklands_access_to_basic_pack(player) and state.count_group("All Ideas", player) >= 5)
+             lambda state: state.stacklands_access_humble_beginnings(player) and state.count_group("All Ideas", player) >= 5)
     
     set_rule(world.get_location("Have 10 Ideas", player),
-             lambda state: state.stacklands_access_to_basic_pack(player) and state.count_group("All Ideas", player) >= 10)
+             lambda state: state.stacklands_access_humble_beginnings(player) and state.count_group("All Ideas", player) >= 10)
     
     set_rule(world.get_location("Have 10 Wood", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.stacklands_access_humble_beginnings(player))
              
     set_rule(world.get_location("Have 10 Stone", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.stacklands_access_humble_beginnings(player))
              
     set_rule(world.get_location("Get an Iron Bar", player),
              lambda state: state.has("Idea: Iron Bar", player) 
@@ -161,7 +161,7 @@ def set_all_rules(world: MultiWorld, player: int):
                            and (state.can_reach_location("Build a Mine", player) or state.has_any(set(["Logic and Reason Booster Pack", "Order and Structure Booster Pack"]), player)))
              
     set_rule(world.get_location("Have 5 Food", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.stacklands_access_humble_beginnings(player))
              
     set_rule(world.get_location("Have 10 Food", player),
              lambda state: state.can_reach_location("Have 5 Food", player))
@@ -169,7 +169,7 @@ def set_all_rules(world: MultiWorld, player: int):
     set_rule(world.get_location("Have 20 Food", player),
              lambda state: state.can_reach_location("Have 10 Food", player)
                            and (state.can_reach_location("Build a Shed", player) # <- Player can build shed to allow more basic food on the board
-                           or (state.stacklands_access_to_basic_pack(player) and state.has("Curious Cuisine Booster Pack", player)))) # <- Or player has access to better foods
+                           or (state.stacklands_access_humble_beginnings(player) and state.has("Curious Cuisine Booster Pack", player)))) # <- Or player has access to better foods
              
     set_rule(world.get_location("Have 50 Food", player), 
              lambda state: state.can_reach_location("Have 20 Food", player)) # <- If player can gather 20, they should be able to gather 50

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -3,84 +3,12 @@ from worlds.AutoWorld import LogicMixin
 from worlds.generic.Rules import set_rule
 
 class StacklandsLogic(LogicMixin):
-    
-    # Basic packs
-    def stacklands_access_to_basic_pack(self, player: int) -> bool:
-        return bool(self.multiworld.worlds[player].options.basic_pack) or self.has_group("Basic Booster Packs", player)
-    
-    def stacklands_access_to_enemies(self, player: int) -> bool:
-        return self.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player)
-    
-    def stacklands_access_all_packs(self, player: int) -> bool:
-        return self.count_group("All Booster Packs", player) >= 8
-    
-    # Equipment
-    def stacklands_can_make_spear(self, player: int) -> bool:
-        return self.has("Idea: Spear", player) and self.stacklands_can_make_stick(player)
-    
-    def stacklands_can_make_sword(self, player: int) -> bool:
-        return self.has_all(set(["Idea: Sword", "Idea: Stick"]), player) and self.stacklands_can_make_iron_bar(player)
-    
-    def stacklands_can_make_magic_staff(self, player: int) -> bool:
-        return (self.stacklands_can_make_smithy(player)
-                and self.stacklands_access_to_enemies(player)
-                and self.stacklands_access_to_basic_pack(player))
-    
-    def stacklands_can_make_magic_wand(self, player: int) -> bool:
-        return self.stacklands_can_make_stick(player) and self.stacklands_access_to_enemies(player)
 
-    # Food
-    def stacklands_can_make_cooked_meat(self, player: int) -> bool:
-        return self.has("Idea: Cooked Meat", player) and self.stacklands_can_make_campfire(player)
-    
-    # Resources
-    def stacklands_access_to_iron_ore(self, player: int) -> bool:
-        return (self.has_any(set(["Explorers Booster Pack", "Logic and Reason Booster Pack", "Order and Structure Booster Pack"]), player)
-                and self.stacklands_access_to_basic_pack(player)) # <- To help prevent above packs spawning before Humble Beginnings)
-    
-    def stacklands_can_make_iron_bar(self, player: int) -> bool:
-        return (self.has("Idea: Iron Bar", player) 
-                and self.stacklands_can_make_smelter(player)
-                and self.stacklands_access_to_iron_ore(player)
-                and self.stacklands_access_to_basic_pack(player))
-    
-    def stacklands_can_make_stick(self, player: int) -> bool:
-        return self.has("Idea: Campfire", player) and self.stacklands_access_to_basic_pack(player)
+    def stacklands_access_enemies(self, player: int) -> bool:
+        return self.stacklands_access_humble_beginnings(player) and self.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"], player))
 
-    # Structures
-    def stacklands_can_make_campfire(self, player: int) -> bool:
-        return self.has("Idea: Campfire", player) and self.stacklands_access_to_basic_pack(player)
-    
-    def stacklands_can_make_farm(self, player: int) -> bool:
-        return (self.has_all(set(["Idea: Farm", "Idea: Brick", "Idea: Plank"]), player)
-               and self.stacklands_access_to_basic_pack(player))
-    
-    def stacklands_can_make_garden(self, player: int) -> bool:
-        return (self.has("Idea: Garden", player)
-               and self.stacklands_access_to_basic_pack(player))
-
-    def stacklands_can_make_house(self, player: int) -> bool:
-        return (self.has_all(set(["Idea: House", "Idea: Stick"]), player)
-                and self.stacklands_access_to_basic_pack(player))
-    
-    def stacklands_can_make_shed(self, player: int) -> bool:
-        return self.has("Idea: Shed", player) and self.stacklands_can_make_stick(player)
-
-    def stacklands_can_make_smelter(self, player: int) -> bool:
-        return (self.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Plank"]), player)
-                and self.stacklands_access_to_basic_pack(player))
-
-    def stacklands_can_make_smithy(self, player: int) -> bool:
-        return self.has("Idea: Smithy", player) and self.stacklands_can_make_iron_bar(player)
-    
-    def stacklands_can_make_temple(self, player: int) -> bool:
-        return (self.has("Idea: Temple", player)
-                and self.stacklands_can_make_house(player)
-                and self.stacklands_can_make_iron_bar(player))
-    
-    # Other
-    def stacklands_can_make_offspring(self, player: int) -> bool:
-        return self.has("Idea: Offspring", player) and self.stacklands_can_make_house(player)
+    def stacklands_access_humble_beginnings(self, player: int) -> bool:
+        return self.can_reach_location("Buy the Humble Beginnings Pack", player)
 
 
 # Set all region and location rules
@@ -93,128 +21,133 @@ def set_all_rules(world: MultiWorld, player: int):
     
     ### Mainland Rules ###
     
-    # 'Welcome Category'
+    # 'Welcome' Category
     set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
-             lambda state: bool(world.worlds[player].options.basic_pack) or state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.has("Humble Beginnings Booster Pack", player))
     
     set_rule(world.get_location("Harvest a Tree using a Villager", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Make a Stick from Wood", player),
-             lambda state: state.stacklands_can_make_stick(player))
+             lambda state: state.has("Idea: Stick", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Grow a Berry Bush using Soil", player),
-             lambda state: state.has("Idea: Growth", player) and state.has_any(set(["Humble Beginnings Booster Pack", "Reap & Sow Booster Pack"]), player))
+             lambda state: state.has("Idea: Growth", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Build a House", player),
-             lambda state: state.stacklands_can_make_house(player))
+             lambda state: state.has("Idea: House", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Get a Second Villager", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Second villager is received from humble beginnings
     
     set_rule(world.get_location("Create Offspring", player),
-             lambda state: state.stacklands_can_make_offspring(player))
+             lambda state: state.has("Idea: Offspring", player) and state.can_reach_location("Build a House", player)) # <- Need a house to make offspring
     
     # 'The Grand Scheme' Category    
     set_rule(world.get_location("Get 3 Villagers", player),
-             lambda state: state.stacklands_can_make_offspring(player))
+             lambda state: state.can_reach_location("Create Offspring", player) or state.can_reach_location("Get a Dog", player)) # <- Third villager can be from offspring or a dog
     
     set_rule(world.get_location("Find the Catacombs", player),
-             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_to_basic_pack(player))
+             lambda state: state.can_reach_location("Get a Second Villager", player) # <- Catacombs can be retrieved from Graveyard (2x Corpses)
+                           or (state.stacklands_access_humble_beginnings(player) and state.has("Explorers Booster Pack", player))) # <- Catacombs can be found from Explorers pack
     
     set_rule(world.get_location("Find a mysterious artifact", player),
-             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_to_basic_pack(player))
+             lambda state: state.can_reach_location("Find the Catacombs", player) # <- Goblet can be retrieved from Catacombs
+                           or state.stacklands_access_humble_beginnings(player)) # <- or from travelling cart
     
     set_rule(world.get_location("Build a Temple", player),
-             lambda state: state.stacklands_can_make_temple(player))
+             lambda state: state.has_all(set(["Idea: Temple", "Idea: Plank", "Idea: Brick"]), player) # <- Ideas required
+                           and state.can_reach_location("Get an Iron Bar", player) # <- Need to be able to create iron bars
+                           and state.can_reach_location("Create Offspring", player)) # <- 3x Villagers Needed
     
     set_rule(world.get_location("Bring the Goblet to the Temple", player),
-             lambda state: state.stacklands_can_make_temple(player))
+             lambda state: state.can_reach_location("Find a mysterious artifact", player) # <- Goblet required
+                           and state.can_reach_location("Build a Temple", player)) # <- Temple required
     
     set_rule(world.get_location("Find a mysterious artifact", player),
-             lambda state: state.stacklands_can_make_temple(player))
+             lambda state: state.stacklands_access_humble_beginnings(player)) # <- Goblet can be found in Catacombs or from travelling cart
     
     set_rule(world.get_location("Kill the Demon", player),
-             lambda state: state.stacklands_can_make_temple(player))
+             lambda state: state.can_reach_location("Bring the Goblet to the Temple", player)) # <- Goblet and Temple required
     
     # 'The Dark Forest' Category 
     # To be added, potentially...
     
     # 'Power & Skill' Category
     set_rule(world.get_location("Train Militia", player),
-             lambda state: state.stacklands_can_make_spear(player))
-    
+             lambda state: (state.has("Idea: Spear", player) and state.can_reach_location("Make a Stick from Wood", player)) # <- Self-craft the spear 
+                           or state.stacklands_access_to_enemies(player)) # <- Get weapons from enemy drop
+
     set_rule(world.get_location("Kill a Rat", player),
-             lambda state: state.has_any(set(["Humble Beginnings Booster Pack", "Explorers Booster Pack"]), player))
+             lambda state: state.stacklands_access_to_humble_beginnings(player)) # <- Rats can drop from Humble Beginnings / Strange Portal
     
     set_rule(world.get_location("Kill a Skeleton", player),
-             lambda state: (state.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player))
-                           and state.stacklands_access_to_basic_pack(player)) # <- To help prevent above packs spawning before Humble Beginnings)
+             lambda state: state.can_reach_location("Find the Catacombs", player) or state.stacklands_access_to_enemies(player)) # Skeletons from enemy packs or catacombs / graveyard / strange portal
     
-    # 'Strengthen Up' Category   
+    # 'Strengthen Up' Category
+    set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
+             lambda state: state.stacklands_access_to_humble_beginnings(player))
+    
     set_rule(world.get_location("Build a Smithy", player),
-             lambda state: state.stacklands_can_make_smithy(player))
+             lambda state: state.has("Idea: Smithy", player) and state.can_reach_location("Get an Iron Bar", player))
     
     set_rule(world.get_location("Train a Wizard", player),
-             lambda state: state.stacklands_can_make_magic_wand(player)
-                           or state.stacklands_can_make_magic_staff)
+             lambda state: (state.has("Idea: Magic Wand", player) and state.can_reach_location("Make a Stick from Wood", player))
+                           or state.stacklands_access_to_enemies(player))
     
     set_rule(world.get_location("Have a Villager with Combat Level 20", player), 
-             lambda state: state.stacklands_access_to_enemies(player)
-                           or state.stacklands_can_make_spear(player)
-                           or state.stacklands_can_make_sword(player)
-                           or state.stacklands_can_make_magic_staff(player)
-                           or state.stacklands_can_make_magic_wand(player))
+             lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player)
+                           and (state.can_reach_location("Train Militia", player) or state.can_reach_location("Train a Wizard", player))
+                           or state.stacklands_access_to_enemies(player))
     
     set_rule(world.get_location("Train a Ninja", player),
-             lambda state: state.has("Idea: Throwing Stars", player) and state.stacklands_can_make_iron_bar(player))
+             lambda state: state.has("Idea: Throwing Stars", player) 
+                           and state.can_reach_location("Get an Iron Bar", player) # <- Needed for recipe
+                           and state.can_reach_location("Build a Smithy", player)) # <- Needed for recipe
     
     # 'Potluck' Category
     set_rule(world.get_location("Start a Campfire", player),
-             lambda state: state.stacklands_can_make_campfire(player))
+             lambda state: state.has("Idea: Campfire", player) and state.can_reach_location("Make a Stick from Wood", player))
     
     set_rule(world.get_location("Cook Raw Meat", player),
-             lambda state: state.has("Idea: Cooked Meat", player)
-                           and state.has_any(set(["Humble Beginnings Booster Pack", "Reap & Sow Booster Pack", "Curious Cuisine Booster Pack"]), player)
-                           and state.stacklands_can_make_campfire(player))
+             lambda state: state.has("Idea: Cooked Meat", player) and state.can_reach_location("Start a Campfire", player))
     
     set_rule(world.get_location("Cook an Omelette", player),
              lambda state: state.has("Idea: Omelette", player)
                            and state.has_any(set(["Reap & Sow Booster Pack", "Curious Cuisine Booster Pack"]), player) # Can get eggs from either pack
-                           and state.stacklands_can_make_campfire(player))
+                           and state.can_reach_location("Start a Campfire", player))
     
     set_rule(world.get_location("Cook a Frittata", player),
              lambda state: state.has("Idea: Frittata", player)
-                           and state.has("Curious Cuisine Booster Pack", player) # Can get potatoes and eggs from Curious Cuisine
-                           and state.stacklands_can_make_campfire(player))
+                           and state.has("Curious Cuisine Booster Pack", player) # <- Potatoes and Eggs can both come from this pack
+                           and state.can_reach_location("Start a Campfire", player)) # <- Needed for recipe
     
     # 'Discovery' Category
     set_rule(world.get_location("Explore a Forest", player),
-             lambda state: state.has("Explorers Booster Pack", player))
+             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Explore a Mountain", player),
-             lambda state: state.has("Explorers Booster Pack", player))
+             lambda state: state.has("Explorers Booster Pack", player) and state.stacklands_access_humble_beginnings(player))
              
     set_rule(world.get_location("Open a Treasure Chest", player),
-             lambda state: state.has("Explorers Booster Pack", player))
+             lambda state: state.stacklands_access_to_basic_pack(player)) # <- Can get early from travelling cart / graveyard / catacombs
              
     set_rule(world.get_location("Find a Graveyard", player),
-             lambda state: state.has("Explorers Booster Pack", player))
+             lambda state: state.can_reach_location("Get a Second Villager", player)) # <- Graveyard can be made with 2x corpses
              
     set_rule(world.get_location("Get a Dog", player),
-             lambda state: (state.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player)
-                            and state.stacklands_access_to_basic_pack(player))) # <- To help prevent above packs spawning before Humble Beginnings, otherwise game is locked)
+             lambda state: state.can_reach_location("Find the Catacombs", player)  # <- Wolf can be found in catacombs / strange portal
+                           or state.stacklands_access_to_enemies(player)) # <- Wolf can be found in enemy packs
              
     set_rule(world.get_location("Train an Explorer", player),
-             lambda state: (state.has("Explorers Booster Pack", player))
-                           and state.stacklands_access_to_basic_pack(player)) # <- To help prevent above pack spawning before Humble Beginnings, otherwise game is locked)
+             lambda state: state.stacklands_access_to_basic_pack(player)) # <- Map can be found from Travelling Cart / Old Tome
              
     # 'Ways and Means' Category
     set_rule(world.get_location("Have 5 Ideas", player),
-             lambda state: state.count_group("All Ideas", player) >= 5)
+             lambda state: state.stacklands_access_to_basic_pack(player) and state.count_group("All Ideas", player) >= 5)
     
     set_rule(world.get_location("Have 10 Ideas", player),
-             lambda state: state.count_group("All Ideas", player) >= 10)
+             lambda state: state.stacklands_access_to_basic_pack(player) and state.count_group("All Ideas", player) >= 10)
     
     set_rule(world.get_location("Have 10 Wood", player),
              lambda state: state.stacklands_access_to_basic_pack(player))
@@ -223,35 +156,68 @@ def set_all_rules(world: MultiWorld, player: int):
              lambda state: state.stacklands_access_to_basic_pack(player))
              
     set_rule(world.get_location("Get an Iron Bar", player),
-             lambda state: state.has("Explorers Booster Pack", player) or state.stacklands_can_make_iron_bar(player))
+             lambda state: state.has("Idea: Iron Bar", player) 
+                           and state.can_reach_location("Build a Smelter", player)
+                           and (state.can_reach_location("Build a Mine", player) or state.has_any(set(["Logic and Reason Booster Pack", "Order and Structure Booster Pack"]), player)))
              
     set_rule(world.get_location("Have 5 Food", player),
              lambda state: state.stacklands_access_to_basic_pack(player))
              
     set_rule(world.get_location("Have 10 Food", player),
-             lambda state: state.stacklands_access_to_basic_pack(player))
+             lambda state: state.can_reach_location("Have 5 Food", player))
              
-    set_rule(world.get_location("Have 20 Food", player), # Likely needs a shed to be able to keep enough food items on the board
-             lambda state: state.has("Curious Cuisine Booster Pack", player) or state.stacklands_can_make_shed(player))
+    set_rule(world.get_location("Have 20 Food", player),
+             lambda state: state.can_reach_location("Have 10 Food", player)
+                           and (state.can_reach_location("Build a Shed", player) # <- Player can build shed to allow more basic food on the board
+                           or (state.stacklands_access_to_basic_pack(player) and state.has("Curious Cuisine Booster Pack", player)))) # <- Or player has access to better foods
              
-    set_rule(world.get_location("Have 50 Food", player), # Likely needs a shed to be able to keep enough food items on the board
-             lambda state: state.has("Curious Cuisine Booster Pack", player) or state.stacklands_can_make_shed(player))
+    set_rule(world.get_location("Have 50 Food", player), 
+             lambda state: state.can_reach_location("Have 20 Food", player)) # <- If player can gather 20, they should be able to gather 50
              
     # 'Construction' Category
     set_rule(world.get_location("Have 3 Houses", player),
-             lambda state: state.stacklands_can_make_house(player))
+             lambda state: state.can_reach_location("Build a House", player))
              
     set_rule(world.get_location("Build a Shed", player),
-             lambda state: state.stacklands_can_make_shed(player))
+             lambda state: state.has("Idea: Shed", player) and state.can_reach_location("Make a Stick from Wood", player))
              
     set_rule(world.get_location("Build a Quarry", player),
-             lambda state: state.has("Idea: Quarry", player) and state.stacklands_access_to_basic_pack(player))
+             lambda state: state.has("Idea: Quarry", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Build a Lumber Camp", player),
-             lambda state: state.has("Idea: Lumber Camp", player) and state.stacklands_access_to_basic_pack(player))
+             lambda state: state.has("Idea: Lumber Camp", player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Build a Farm", player),
-             lambda state: state.stacklands_can_make_farm(player))
+             lambda state: state.has_all(set(["Idea: Farm", "Idea: Brick", "Idea: Plank"]), player) and state.stacklands_access_humble_beginnings(player))
     
     set_rule(world.get_location("Build a Brickyard", player),
-             lambda state: state.has("Idea: Brickyard", player) and state.stacklands_can_make_iron_bar(player))
+             lambda state: state.has_all(set(["Idea: Brickyard", "Idea: Brick"]), player) and state.can_reach_location("Get an Iron Bar", player))
+    
+    set_rule(world.get_location("Sell a Card at a Market", player),
+             lambda state: state.has("Idea: Market", player) and state.stacklands_access_humble_beginnings(player))
+    
+    # 'Longevity' Category
+    set_rule(world.get_location("Reach Moon 6", player),
+             lambda state: state.stacklands_access_humble_beginnings(player))
+    
+    set_rule(world.get_location("Reach Moon 12", player),
+             lambda state: state.can_reach_location("Reach Moon 6", player))
+    
+    set_rule(world.get_location("Reach Moon 24", player),
+             lambda state: state.can_reach_location("Reach Moon 12", player))
+             
+    set_rule(world.get_location("Reach Moon 36", player),
+             lambda state: state.can_reach_location("Reach Moon 24", player))
+    
+    # 'Side Quests' Category
+    set_rule(world.get_location("Build a Garden", player),
+             lambda state: state.has("Idea: Garden", player) and state.can_reach_location("Grow a Berry Bush using Soil", player))
+    
+    set_rule(world.get_location("Build a Sawmill", player),
+             lambda state: state.has_all(set(["Idea: Sawmill", "Idea: Plank"]), player) and state.stacklands_access_humble_beginnings(player))
+    
+    set_rule(world.get_location("Build a Mine", player),
+             lambda state: state.has("Idea: Iron Mine", player) and state.stacklands_access_humble_beginnings(player))
+    
+    set_rule(world.get_location("Build a Smelter", player),
+             lambda state: state.has_all(set(["Idea: Smelter", "Idea: Brick"]), player) and state.stacklands_access_humble_beginnings(player))

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -1,15 +1,5 @@
 from BaseClasses import MultiWorld
-from worlds.AutoWorld import LogicMixin
 from worlds.generic.Rules import set_rule
-
-class StacklandsLogic(LogicMixin):
-
-    def stacklands_access_enemies(self, player: int) -> bool:
-        return self.stacklands_access_humble_beginnings(player) and self.has_any(set(["Explorers Booster Pack", "The Armory Booster Pack"]), player)
-
-    def stacklands_access_humble_beginnings(self, player: int) -> bool:
-        return self.can_reach_location("Buy the Humble Beginnings Pack", player)
-
 
 # Set all region and location rules
 def set_all_rules(world: MultiWorld, player: int):
@@ -23,7 +13,7 @@ def set_all_rules(world: MultiWorld, player: int):
 
     # Coins
     set_rule(world.get_location("Have 10 Coins", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Have 30 Coins", player),
              lambda state: state.has("Idea: Coin Chest", player) and
@@ -34,17 +24,17 @@ def set_all_rules(world: MultiWorld, player: int):
 
     # Ideas
     set_rule(world.get_location("Have 5 Ideas", player),
-             lambda state: state.count_group("Mainland Ideas", player) >= 5)
+             lambda state: state.count_group("All Ideas", player) >= 5)
     
     set_rule(world.get_location("Have 10 Ideas", player),
-             lambda state: state.count_group("Mainland Ideas", player) >= 10)
+             lambda state: state.count_group("All Ideas", player) >= 10)
     
     # Moons
     set_rule(world.get_location("Reach Moon 6", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Reach Moon 12", player), # Trialling this to help release un-required boosters
-             lambda state: state.has("Seeking Wisdom Booster Pack") and
+             lambda state: state.has("Seeking Wisdom Booster Pack", player) and
                            state.can_reach_location("Reach Moon 6", player))
     
     set_rule(world.get_location("Buy something from a Travelling Cart", player),
@@ -59,23 +49,27 @@ def set_all_rules(world: MultiWorld, player: int):
                            state.can_reach_location("Reach Moon 24", player))
     
     # Miscellaneous
+    set_rule(world.get_location("Buy the Humble Beginnings Pack", player),
+             lambda state: world.worlds[player].options.basic_pack.value == True or 
+                           state.has("Humble Beginnings Booster Pack", player))
+
     set_rule(world.get_location("Sell a Card at a Market", player),
              lambda state: state.has_all(set(["Idea: Market", "Idea: Brick", "Idea: Plank"]), player))
 
     # 'Combat' Path
     set_rule(world.get_location("Make a Villager wear a Rabbit Hat", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Kill a Rat", player),
              lambda state: state.can_reach_location("Make a Villager wear a Rabbit Hat", player))
     
     set_rule(world.get_location("Train Militia", player), # Trialling this
-             lambda state: state.has("Explorers Booster Pack") and
+             lambda state: state.has("Explorers Booster Pack", player) and
                            state.has_any(set(["Idea: Slingshot", "Idea: Spear"]), player) and
                            state.can_reach_location("Kill a Rat", player))
     
     set_rule(world.get_location("Train a Wizard", player), # Trialling this
-             lambda state: state.has("Explorers Booster Pack") and
+             lambda state: state.has("Explorers Booster Pack", player) and
                            state.has("Idea: Magic Wand", player) and
                            state.can_reach_location("Kill a Rat", player))
     
@@ -95,7 +89,8 @@ def set_all_rules(world: MultiWorld, player: int):
 
     # 'Cooking' Path
     set_rule(world.get_location("Make a Stick from Wood", player),
-             lambda state: state.has_all(set(["Idea: Stick", "Humble Beginnings Booster Pack"]), player))
+             lambda state: state.has("Idea: Stick", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Start a Campfire", player),
              lambda state: state.has("Idea: Campfire", player) and
@@ -115,11 +110,11 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Exploring' Path
     set_rule(world.get_location("Find a Graveyard", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player)) # <- Created with 2x Corpse
+             lambda state: state.has("Explorers Booster Pack", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Find the Catacombs", player),
-             lambda state: state.has("Explorers Booster Pack", player) and
-                           state.can_reach_location("Find a Graveyard", player)) # <- Can be Found from Graveyard
+             lambda state: state.can_reach_location("Find a Graveyard", player)) # <- Can be Found from Graveyard
 
     set_rule(world.get_location("Open a Treasure Chest", player),
              lambda state: state.can_reach_location("Find the Catacombs", player))
@@ -141,7 +136,7 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Farming' Path
     set_rule(world.get_location("Have 5 Food", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Grow a Berry Bush using Soil", player),
              lambda state: state.has("Idea: Growth", player) and
@@ -170,7 +165,8 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Metal' Path
     set_rule(world.get_location("Build a Mine", player),
-             lambda state: state.has_all(set(["Idea: Iron Mine", "Humble Beginnings Booster Pack"]), player))
+             lambda state: state.has("Idea: Iron Mine", player) and
+                           state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Build a Smelter", player),
              lambda state: state.has_all(set(["Idea: Smelter", "Idea: Brick", "Idea: Plank"]), player) and
@@ -186,7 +182,7 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Stone' Path
     set_rule(world.get_location("Have 10 Stone", player),
-             lambda state: state.has("Humble Beginnings Booster Pack", player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Build a Quarry", player),
              lambda state: state.has_all(set(["Idea: Quarry", "Idea: Brick"]), player) and
@@ -199,7 +195,7 @@ def set_all_rules(world: MultiWorld, player: int):
 
     # 'Villager' Path
     set_rule(world.get_location("Get a Second Villager", player),
-             lambda state: state.has("Humble Beginnings Boster Pack")) # <- Second villager obtained from humble beginnings
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
 
     set_rule(world.get_location("Build a House", player),
              lambda state: state.has("Idea: House", player) 
@@ -217,7 +213,7 @@ def set_all_rules(world: MultiWorld, player: int):
 
     # 'Wood' Path
     set_rule(world.get_location("Harvest a Tree using a Villager", player),
-             lambda state: state.stacklands_access_humble_beginnings(player))
+             lambda state: state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
     set_rule(world.get_location("Have 10 Wood", player),
              lambda state: state.can_reach_location("Harvest a Tree using a Villager", player))
@@ -233,7 +229,7 @@ def set_all_rules(world: MultiWorld, player: int):
     
     # 'Goal' Path (Other paths converge here)
     set_rule(world.get_location("Build a Temple", player), # Trialling this
-             lambda state: state.has("Idea: Temple") and
+             lambda state: state.has("Idea: Temple", player) and
                            state.can_reach_location("Get 3 Villagers", player) and # <- 'House' is included as part of this path
                            state.can_reach_location("Get an Iron Bar", player) and # <- 'Smelter' is included as part of this path
                            state.can_reach_location("Build a Quarry", player) and # <- 'Brick' is included as part of this path
@@ -249,5 +245,7 @@ def set_all_rules(world: MultiWorld, player: int):
     set_rule(world.get_location("Kill the Demon", player),
              lambda state: state.can_reach_location("Bring the Goblet to the Temple", player))
     
-    set_rule(world.get_location("Kill the Demon Lord", player),
-             lambda state: state.can_reach_location("Kill the Demon", player))
+    # Include this rule if demon lord is the goal
+    if world.worlds[player].options.goal == 1:
+        set_rule(world.get_location("Kill the Demon Lord", player),
+                lambda state: state.can_reach_location("Kill the Demon", player))

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -31,11 +31,11 @@ class StacklandsWorld(World):
     def __init(self, multiworld, player):
         super(StacklandsWorld, self).__init(multiworld, player)
 
-    # def generate_early(self):
-    #     self.basic_pack: bool = self.options.basic_pack.value
-    #     self.death_link: bool = self.options.death_link.value
-    #     self.goal: int = self.options.goal.value
-    #     self.pause_enabled: bool = self.options.pause_enabled.value
+    def generate_early(self):
+        self.basic_pack: bool = self.options.basic_pack.value
+        self.death_link: bool = self.options.death_link.value
+        self.goal: int = self.options.goal.value
+        self.pause_enabled: bool = self.options.pause_enabled.value
     
     def create_event(self, event: str):
         return StacklandsItem(event, ItemClassification.progression_skip_balancing, None, self.player)

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -30,12 +30,6 @@ class StacklandsWorld(World):
     
     def __init(self, multiworld, player):
         super(StacklandsWorld, self).__init(multiworld, player)
-
-    def generate_early(self):
-        self.basic_pack: bool = self.options.basic_pack.value
-        self.death_link: bool = self.options.death_link.value
-        self.goal: int = self.options.goal.value
-        self.pause_enabled: bool = self.options.pause_enabled.value
     
     def create_event(self, event: str):
         return StacklandsItem(event, ItemClassification.progression_skip_balancing, None, self.player)
@@ -51,10 +45,10 @@ class StacklandsWorld(World):
     # Fill the slot data
     def fill_slot_data(self) -> Dict[str, Any]:
         return {
-            "BasicPack": self.basic_pack,
-            "DeathLink": self.death_link,
-            "Goal": self.goal,
-            "PauseEnabled": self.pause_enabled
+            "BasicPack": bool(self.options.basic_pack.value),
+            "DeathLink": bool(self.options.death_link.value),
+            "Goal": int(self.options.goal.value),
+            "PauseEnabled": bool(self.options.pause_enabled.value)
         }
     
     # Set all access rules

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -1,11 +1,11 @@
 from typing import Dict, Any
 from .Options import StacklandsOptions
-from .Items import StacklandsItem, create_all_items, item_group_table, lookup_name_to_id as items_lookup_name_to_id
-from .Locations import lookup_name_to_id as locations_lookup_name_to_id
+from .Items import StacklandsItem, create_all_items, item_table
+from .Locations import location_table
 from .Regions import create_all_regions
-from .Rules import set_all_rules
+from .Rules import set_rules
 from worlds.AutoWorld import World, WebWorld
-from BaseClasses import Item, ItemClassification, Location, Region
+from BaseClasses import Item
 
 class StacklandsWeb(WebWorld):
     theme = "jungle"
@@ -18,29 +18,26 @@ class StacklandsWorld(World):
     
     game = "Stacklands"
     web = StacklandsWeb()
-    
-    item_name_to_id = items_lookup_name_to_id
-    location_name_to_id = locations_lookup_name_to_id
-    item_name_groups = item_group_table
+    topology_present = False
+    item_name_to_id = { name: data.code for name, data in item_table.items() }
+    location_name_to_id = { name: data.code for name, data in location_table.items() }
+    # item_name_groups = item_group_table
 
     options_dataclass = StacklandsOptions
     options: StacklandsOptions
     
     required_client_version = (0, 1, 9)
     
-    def __init(self, multiworld, player):
-        super(StacklandsWorld, self).__init(multiworld, player)
-    
-    def create_event(self, event: str):
-        return StacklandsItem(event, ItemClassification.progression_skip_balancing, None, self.player)
-    
     # Create all items
-    def create_items(self) -> None:
-        create_all_items(self.multiworld, self.player, self.options)
+    def create_items(self):
+        create_all_items(self.multiworld, self.player)
+
+    def create_item(self, name: str) -> Item:
+        return StacklandsItem(name, self.player)
     
     # Create all regions (and place all locations within each region)
-    def create_regions(self) -> None:
-        create_all_regions(self.multiworld, self.player, self.options)
+    def create_regions(self):
+        create_all_regions(self.multiworld, self.player)
     
     # Fill the slot data
     def fill_slot_data(self) -> Dict[str, Any]:
@@ -53,4 +50,4 @@ class StacklandsWorld(World):
     
     # Set all access rules
     def set_rules(self):
-        set_all_rules(self.multiworld, self.player)
+        set_rules(self.multiworld, self.player)

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -30,12 +30,18 @@ class StacklandsWorld(World):
     
     def __init(self, multiworld, player):
         super(StacklandsWorld, self).__init(multiworld, player)
+
+    # def generate_early(self):
+    #     self.basic_pack: bool = self.options.basic_pack.value
+    #     self.death_link: bool = self.options.death_link.value
+    #     self.goal: int = self.options.goal.value
+    #     self.pause_enabled: bool = self.options.pause_enabled.value
     
     def create_event(self, event: str):
         return StacklandsItem(event, ItemClassification.progression_skip_balancing, None, self.player)
     
     # Create all items
-    def create_items(self):
+    def create_items(self) -> None:
         create_all_items(self.multiworld, self.player, self.options)
     
     # Create all regions (and place all locations within each region)
@@ -45,10 +51,10 @@ class StacklandsWorld(World):
     # Fill the slot data
     def fill_slot_data(self) -> Dict[str, Any]:
         return {
-            "BasicPack": bool(self.options.basic_pack.value),
-            "DeathLink": bool(self.options.death_link.value),
-            "Goal": bool(self.options.goal.value),
-            "PauseEnabled": bool(self.options.pause_enabled.value)
+            "BasicPack": self.basic_pack,
+            "DeathLink": self.death_link,
+            "Goal": self.goal,
+            "PauseEnabled": self.pause_enabled
         }
     
     # Set all access rules


### PR DESCRIPTION
## Changes
- Rules for `Locations` have been completely re-written to better balance the playthrough of the game.
- As a result of the above, spheres are now correctly generated.
- `basic_pack` YAML option has been removed and can now be implemented via `start_inventory`
- `fuzz.py` _(from [Eijebong/Archipelago-fuzzer](https://github.com/Eijebong/Archipelago-fuzzer))_ implemented to test apworld stability