### PR TITLE
'Unlock all Packs' Location Reinstated

### DIFF
--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -38,6 +38,7 @@ location_table: List[LocationData] = [
     LocationData("Create Offspring"                                    , "Mainland", LocationProgressType.DEFAULT),
     
     # 'The Grand Scheme' Category
+    LocationData("Unlock all Packs"                                    , "Mainland", LocationProgressType.EXCLUDED), # <- Achievable only from receiving items from checks
     LocationData("Get 3 Villagers"                                     , "Mainland", LocationProgressType.DEFAULT),
     LocationData("Find the Catacombs"                                  , "Mainland", LocationProgressType.DEFAULT),
     LocationData("Find a mysterious artifact"                          , "Mainland", LocationProgressType.DEFAULT),

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -99,6 +99,9 @@ def set_rules(world: MultiWorld, player: int):
              lambda state: state.sl_has_all_ideas(["Market", "Brick", "Plank"], player) and
                            state.can_reach_location("Buy the Humble Beginnings Pack", player))
     
+    set_rule(world.get_location("Unlock all Packs", player),
+             lambda state: state.has_group_unique("All Booster Packs", player, 8))
+    
     
     
     # 'Starting' Path - Quests that can be achieved immediately


### PR DESCRIPTION
## Changes
- `Unlock all Packs` quest has been reinstated as a location in line with the `v.0.0.12` release for the [Stacklands Randomizer](https://github.com/JammyGeeza/Stacklands-Randomizer)