### PR TITLE
Stacklands v0.2.5

### DIFF
--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -76,6 +76,7 @@ item_table: List[ItemData] = [
     ItemData("Idea: Sword"                          , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression),
     ItemData("Idea: Temple"                         , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression_skip_balancing), # <- Try not to release this too early
     ItemData("Idea: Throwing Stars"                 , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression_skip_balancing), # <- Try not to release this too early
+    ItemData("Idea: University"                     , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression),
     ItemData("Idea: Warehouse"                      , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression_skip_balancing), # <- Try not to release this too early
     ItemData("Idea: Wooden Shield"                  , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.NONE              , ItemClassification.progression),
 
@@ -113,7 +114,6 @@ item_table: List[ItemData] = [
     ItemData("Idea: Iron Mine"                      , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.Structuresanity   , ItemClassification.useful),
     ItemData("Idea: Resource Chest"                 , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.Structuresanity   , ItemClassification.useful),
     ItemData("Idea: Sawmill"                        , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.Structuresanity   , ItemClassification.useful),
-    ItemData("Idea: University"                     , RegionFlags.Mainland              , ItemType.Idea         , OptionFlags.Structuresanity   , ItemClassification.filler),
 
 #endregion
 

--- a/worlds/stacklands/Items.py
+++ b/worlds/stacklands/Items.py
@@ -362,8 +362,8 @@ def create_trap_items(world: MultiWorld, player: int, options: StacklandsOptions
 
             # Select traps using trap weights
             trap_selection = world.random.choices(
-                population=list(world.trap_weights.keys()),
-                weights=list(world.trap_weights.values()),
+                population=list(world.trap_weights[player].keys()),
+                weights=list(world.trap_weights[player].values()),
                 k=trap_count
             )
 
@@ -418,8 +418,8 @@ def create_filler_items(world: MultiWorld, player: int, items: List[ItemData], o
 
             # Select filler boosters using weights
             booster_selection = world.random.choices(
-                population=list(world.filler_booster_weights.keys()),
-                weights=list(world.filler_booster_weights.values()),
+                population=list(world.filler_booster_weights[player].keys()),
+                weights=list(world.filler_booster_weights[player].values()),
                 k=unfilled_count
             )
 

--- a/worlds/stacklands/Locations.py
+++ b/worlds/stacklands/Locations.py
@@ -141,6 +141,8 @@ location_table: List[LocationData] = [
     LocationData("Have 10 Planks"                                       , RegionFlags.Mainland      , ProgressionPhase.PhaseTwo     , CheckType.Check    , OptionFlags.NONE           , LocationProgressType.DEFAULT ),
     LocationData("Have 10 Sticks"                                       , RegionFlags.Mainland      , ProgressionPhase.PhaseOne     , CheckType.Check    , OptionFlags.NONE           , LocationProgressType.DEFAULT ),
 
+    LocationData("Research at a University"                             , RegionFlags.Mainland      , ProgressionPhase.PhaseTwo     , CheckType.Check    , OptionFlags.NONE           , LocationProgressType.DEFAULT ),
+
 #endregion
 
 #region The Dark Forest Quests
@@ -351,7 +353,7 @@ location_table: List[LocationData] = [
     LocationData("Build a Sawmill"                                      , RegionFlags.Mainland      , ProgressionPhase.PhaseThree   , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
     LocationData("Build a Smelter"                                      , RegionFlags.Mainland      , ProgressionPhase.PhaseTwo     , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
     LocationData("Build a Stove"                                        , RegionFlags.Mainland      , ProgressionPhase.PhaseThree   , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
-    LocationData("Build a University"                                   , RegionFlags.Mainland      , ProgressionPhase.PhaseThree   , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
+    LocationData("Build a University"                                   , RegionFlags.Mainland      , ProgressionPhase.PhaseTwo     , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
     LocationData("Build a Warehouse"                                    , RegionFlags.Mainland      , ProgressionPhase.PhaseThree   , CheckType.Check    , OptionFlags.Structuresanity  , LocationProgressType.DEFAULT ),
 
     # The Island

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -645,6 +645,11 @@ def set_rules(world: MultiWorld, player: int):
    set_rule(world.get_location("Have 10 Sticks", player),
             lambda state:  # Phase one
                state.sl_has_idea("Stick", player))
+   
+   # Misc
+   set_rule(world.get_location("Research at a University", player),
+            lambda state:  # Phase Three
+               state.sl_has_all_ideas(["Brick", "Magic Wand", "University"], player))
 
    #endregion
 
@@ -1502,6 +1507,10 @@ def set_rules(world: MultiWorld, player: int):
                lambda state:  # Phase Three
                   state.can_reach_location("Get an Iron Bar", player)
                   and state.sl_has_idea("Stove", player))
+      
+      set_rule(world.get_location("Build a University", player),
+               lambda state: # Phase Two
+                  state.sl_has_all_ideas(["Brick", "University"]))
 
       set_rule(world.get_location("Build a Warehouse", player),
                lambda state:  # Phase Three

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -1589,9 +1589,9 @@ def set_rules(world: MultiWorld, player: int):
    set_rule(world.get_location("Goal Complete", player),
             lambda state: (
                bool(options.goal.value & (GoalFlags.AllBosses | GoalFlags.RandomBoss))
-               and (not bool(world.goal_boards & RegionFlags.Mainland) or state.has("Demon", player))
-               and (not bool(world.goal_boards & RegionFlags.Forest) or state.has("Wicked Witch", player))
-               and (not bool(world.goal_boards & RegionFlags.Island) or state.has("Demon Lord", player))
+               and (not bool(world.goal_boards[player] & RegionFlags.Mainland) or state.has("Demon", player))
+               and (not bool(world.goal_boards[player] & RegionFlags.Forest) or state.has("Wicked Witch", player))
+               and (not bool(world.goal_boards[player] & RegionFlags.Island) or state.has("Demon Lord", player))
             ))
                
 

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -86,7 +86,7 @@ class StacklandsWorld(World):
         # Set goal bosses as all bosses if selected, otherwise select random boss
         self.multiworld.goal_boards = (
             self.options.boards.value 
-            if self.options.goal.value is GoalFlags.AllBosses else 
+            if self.options.goal.value is GoalFlags.AllBosses.value else 
             self.multiworld.random.choices(
                 population=list(goal_weights.keys()),
                 weights=list(goal_weights.values()),

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -76,32 +76,44 @@ class StacklandsWorld(World):
 
     def generate_early(self) -> None:
 
+        if not hasattr(self.multiworld, "goal_weights"):
+            self.multiworld.goal_weights = {}
+
         # Define goal weights based on options
-        goal_weights: Dict[RegionFlags, int] = {
+        self.multiworld.goal_weights[self.player] = {
             RegionFlags.Mainland: 1 if bool(self.options.boards.value & RegionFlags.Mainland) else 0,
             RegionFlags.Forest: 1 if bool(self.options.boards.value & RegionFlags.Forest) else 0,
             RegionFlags.Island: 1 if bool(self.options.boards.value & RegionFlags.Island) else 0
         }
 
+        if not hasattr(self.multiworld, "goal_boards"):
+            self.multiworld.goal_boards = {}
+
         # Set goal bosses as all bosses if selected, otherwise select random boss
-        self.multiworld.goal_boards = (
+        self.multiworld.goal_boards[self.player] = (
             self.options.boards.value 
-            if self.options.goal.value is GoalFlags.AllBosses.value else 
-            self.multiworld.random.choices(
-                population=list(goal_weights.keys()),
-                weights=list(goal_weights.values()),
+            if self.options.goal.value == GoalFlags.AllBosses.value else 
+            self.random.choices(
+                population=list(self.multiworld.goal_weights[self.player].keys()),
+                weights=list(self.multiworld.goal_weights[self.player].values()),
                 k=1
             ).pop()
         )
 
+        if not hasattr(self.multiworld, "filler_booster_weights"):
+            self.multiworld.filler_booster_weights = {}
+
         # Get resource booster item weights
-        self.multiworld.filler_booster_weights = {
+        self.multiworld.filler_booster_weights[self.player] = {
             "Mainland Resource Booster Pack": 1 if bool(self.options.boards.value & RegionFlags.Mainland) else 0,
             "Island Resource Booster Pack": 1 if bool(self.options.boards.value & RegionFlags.Island) else 0,
         }
 
+        if not hasattr(self.multiworld, "trap_weights"):
+            self.multiworld.trap_weights = {}
+
         # Get trap item weights
-        self.multiworld.trap_weights = {
+        self.multiworld.trap_weights[self.player] = {
             "Feed Villagers Trap": self.options.feed_villagers_trap_weight.value,
             "Mob Trap": self.options.mob_trap_weight.value,
             "Sell Cards Trap": self.options.sell_cards_trap_weight.value,
@@ -146,7 +158,7 @@ class StacklandsWorld(World):
 
         # Add additional data to slot data
         slot_data.update({
-            "goal_boards": self.multiworld.goal_boards,
+            "goal_boards": self.multiworld.goal_boards[self.player],
             "version": "0.2.4"
         })
 

--- a/worlds/stacklands/__init__.py
+++ b/worlds/stacklands/__init__.py
@@ -159,7 +159,7 @@ class StacklandsWorld(World):
         # Add additional data to slot data
         slot_data.update({
             "goal_boards": self.multiworld.goal_boards[self.player],
-            "version": "0.2.4"
+            "version": "0.2.5"
         })
 
         return slot_data

--- a/worlds/stacklands/archipelago.json
+++ b/worlds/stacklands/archipelago.json
@@ -1,0 +1,6 @@
+{
+    "game": "Stacklands",
+    "minimum_ap_version": "0.6.7",
+    "world_version": "0.2.5",
+    "authors": ["chandler05", "JammyGeeza"]
+}


### PR DESCRIPTION
- Fixes issue causing multiple stacklands generations in same multiworld from receiving shared goal and filler/trap weightings.
- Fixes issue causing `all_bosses` goal to generate incorrectly.