### PR TITLE
Cursed Words v0.3.0

### DIFF
--- a/worlds/cursed_words/Items.py
+++ b/worlds/cursed_words/Items.py
@@ -12,25 +12,26 @@ class CursedWordsItem:
 
     def __init__(self, json_data: dict):
         self.name: str = json_data.get("name")
+        self.character_tags: List[str] = json_data.get("character_tags", [])
         self.classification: ItemClassification = ItemClassification(json_data.get("classification", ItemClassification.filler.value))
         self.count: int = json_data.get("count", 1)
         self.groups: List[str] = json_data.get("groups", [])
+        self.option_tags: List[str] = json_data.get("option_tags", [])
         self.region: str = json_data.get("region")
-        self.tags: List[str] = json_data.get("tags", [])
 
-    def has_tags(self, tags: List[str]) -> bool:
-        """Check if all of this item's tags are present in a tags list"""
-        return set(self.tags).issubset(set(tags))
+    def has_character_tags(self, tags: List[str]) -> bool:
+        """Check if this item's character tags contains at least one tag from a list."""
+        return not self.character_tags or bool(set(self.character_tags) & set(tags))
+    
+    def has_option_tags(self, tags: List[str]) -> bool:
+        """Check if this item's option tags contains at least one tag from a list."""
+        return not self.option_tags or bool(set(self.option_tags) & set(tags))
 
     def is_classification(self, classification: ItemClassification) -> bool:
         """Check if this item has a matching classification flag"""
         return self.classification & classification if classification != ItemClassification.filler else self.classification == classification
 
 # Read items data from JSON config
-
-# with open(os.path.join(os.path.dirname(__file__), 'data', 'items.json'), 'r') as file:
-#     _items_data = json.loads(file.read())
-
 _file_data = pkgutil.get_data(__name__, 'data/items.json')
 _items_data = json.loads(_file_data)
 
@@ -61,12 +62,21 @@ def generate_items(world: World):
 
     # logging.info(f"Generating items for multiworld...")
 
-    # Get all progression/useful items with matching tags from configuration options,
-    # excluding the starting character which is already precollected
+    # Get all pre-collected item names
+    precollected_item_names = [
+        item.name for item in world.multiworld.precollected_items[world.player]
+    ]
+
+    # Get all progression/useful items with matching tags from configuration options, excluding the following pre-collected items:
+    # - The starting character
+    # - Starting Stamps
+    # - Starting Stickers
     enabled_items: List[CursedWordsItem] = [
         item for item in item_table
-        if item.has_tags(world.tags) and item.is_classification(ItemClassification.progression | ItemClassification.useful)
-        and item.name != world.start_character
+        if item.has_character_tags(world.character_tags)
+        and item.has_option_tags(world.option_tags)
+        and item.is_classification(ItemClassification.progression | ItemClassification.useful)
+        and item.name not in precollected_item_names
     ]
 
     # logging.info(f"Found {len(enabled_items)} enabled progression/useful items for the multiworld")
@@ -85,7 +95,7 @@ def generate_items(world: World):
     unfilled_location_count: int = len(world.multiworld.get_unfilled_locations(world.player))
     required_filler_count: int = unfilled_location_count - len([item for item in world.multiworld.itempool if item.player == world.player])
 
-    logging.info(f"Unfilled locations for player: {unfilled_location_count}")
+    # logging.info(f"Unfilled locations for player: {unfilled_location_count}")
     logging.info(f"Required filler for player: {required_filler_count}")
 
 
@@ -102,7 +112,9 @@ def generate_filler_items(world: World, amount: int) -> List[Item]:
     # Get applicable filler items
     enabled_filler_items = [
         item for item in item_table 
-        if item.has_tags(world.tags) and item.is_classification(ItemClassification.filler)
+        if item.has_character_tags(world.character_tags)
+        and item.has_option_tags(world.option_tags)
+        and item.is_classification(ItemClassification.filler)
     ]
 
     # Randomly select from filler items

--- a/worlds/cursed_words/Items.py
+++ b/worlds/cursed_words/Items.py
@@ -1,6 +1,7 @@
 from BaseClasses import Item, ItemClassification, MultiWorld, Optional
 from dataclasses import dataclass
 import json, logging, os
+import pkgutil
 from typing import Dict, List, NamedTuple
 from worlds.AutoWorld import World
 
@@ -26,8 +27,12 @@ class CursedWordsItem:
         return self.classification & classification if classification != ItemClassification.filler else self.classification == classification
 
 # Read items data from JSON config
-with open(os.path.join(os.path.dirname(__file__), 'data\\items.json'), 'r') as file:
-    _items_data = json.loads(file.read())
+
+# with open(os.path.join(os.path.dirname(__file__), 'data', 'items.json'), 'r') as file:
+#     _items_data = json.loads(file.read())
+
+_file_data = pkgutil.get_data(__name__, 'data/items.json')
+_items_data = json.loads(_file_data)
 
 # Parse as items
 item_table: List[CursedWordsItem] = [ CursedWordsItem(item) for item in _items_data ]

--- a/worlds/cursed_words/Items.py
+++ b/worlds/cursed_words/Items.py
@@ -81,7 +81,7 @@ def generate_items(world: World):
 
     # Check if all locations would be filled
     unfilled_location_count: int = len(world.multiworld.get_unfilled_locations(world.player))
-    required_filler_count: int = unfilled_location_count - len(world.multiworld.itempool)
+    required_filler_count: int = unfilled_location_count - len([item for item in world.multiworld.itempool if item.player == world.player])
 
     # Append filler items if required
     if required_filler_count > 0:
@@ -95,8 +95,8 @@ def generate_filler_items(world: World, amount: int) -> List[Item]:
 
     # Get applicable filler items
     enabled_filler_items = [
-        itm for itm in item_table 
-        if item.has_tags(world.tags) and itm.is_classification(ItemClassification.filler)
+        item for item in item_table 
+        if item.has_tags(world.tags) and item.is_classification(ItemClassification.filler)
     ]
 
     # Randomly select from filler items
@@ -105,4 +105,4 @@ def generate_filler_items(world: World, amount: int) -> List[Item]:
         k=amount
     )
 
-    return [ Item(itm.name, itm.classification, itm.id, world.player) for itm in selected_filler ]
+    return [ Item(item.name, item.classification, item.id, world.player) for item in selected_filler ]

--- a/worlds/cursed_words/Items.py
+++ b/worlds/cursed_words/Items.py
@@ -85,9 +85,13 @@ def generate_items(world: World):
     unfilled_location_count: int = len(world.multiworld.get_unfilled_locations(world.player))
     required_filler_count: int = unfilled_location_count - len([item for item in world.multiworld.itempool if item.player == world.player])
 
+    logging.info(f"Unfilled locations for player: {unfilled_location_count}")
+    logging.info(f"Required filler for player: {required_filler_count}")
+
+
     # Append filler items if required
     if required_filler_count > 0:
-        # logging.info(f"Found {required_filler_count} empty spaces for filler items")
+        logging.info(f"Found {required_filler_count} empty spaces for filler items")
         world.multiworld.itempool += generate_filler_items(world, required_filler_count)
 
 def generate_filler_items(world: World, amount: int) -> List[Item]:

--- a/worlds/cursed_words/Items.py
+++ b/worlds/cursed_words/Items.py
@@ -61,10 +61,12 @@ def generate_items(world: World):
 
     # logging.info(f"Generating items for multiworld...")
 
-    # Get all progression/useful items with matching tags from configuration options
+    # Get all progression/useful items with matching tags from configuration options,
+    # excluding the starting character which is already precollected
     enabled_items: List[CursedWordsItem] = [
         item for item in item_table
         if item.has_tags(world.tags) and item.is_classification(ItemClassification.progression | ItemClassification.useful)
+        and item.name != world.start_character
     ]
 
     # logging.info(f"Found {len(enabled_items)} enabled progression/useful items for the multiworld")

--- a/worlds/cursed_words/Locations.py
+++ b/worlds/cursed_words/Locations.py
@@ -1,6 +1,7 @@
 from BaseClasses import Item, ItemClassification, MultiWorld
 from dataclasses import dataclass
 import json, logging, os
+import pkgutil
 from typing import Dict, List, NamedTuple, Optional
 from worlds.AutoWorld import World
 
@@ -25,8 +26,11 @@ class CursedWordsLocation:
         return set(self.tags).issubset(set(tags))
 
 # Read items data from JSON
-with open(os.path.join(os.path.dirname(__file__), 'data\\locations.json'), 'r') as file:
-    _locations_data = json.loads(file.read())
+# with open(os.path.join(os.path.dirname(__file__), 'data', 'locations.json'), 'r') as file:
+#     _locations_data = json.loads(file.read())
+
+_file_data = pkgutil.get_data(__name__, 'data/locations.json')
+_locations_data = json.loads(_file_data)
 
 # Parse as location objects
 location_table: List[CursedWordsLocation] = [ CursedWordsLocation(data) for data in _locations_data ]

--- a/worlds/cursed_words/Locations.py
+++ b/worlds/cursed_words/Locations.py
@@ -12,23 +12,27 @@ class CursedWordsLocation:
 
     def __init__(self, json_data: Dict[any, any]):
         self.access_rule: Optional[Dict[str, any]] = json_data.get("access_rule", {})
+        self.character_tags: List[str] = json_data.get("character_tags", [])
         self.count: int = json_data.get("count", 1)
+        self.count_start: int = json_data.get("count_start", 1)
+        self.count_step: int = json_data.get("count_step", 1)
         self.name: str = json_data.get("name")
+        self.option_tags: List[str] = json_data.get("option_tags", [])
         self.region: str = json_data.get("region")
-        self.tags: List[str] = json_data.get("tags", [])
 
     def is_for_region(self, region: str) -> bool:
         """Check if this location is for a specified region."""
         return self.region == region
 
-    def has_tags(self, tags: List[str]) -> bool:
-        """Check if all of this location's tags are present in a tags list"""
-        return set(self.tags).issubset(set(tags))
+    def has_character_tags(self, tags: List[str]) -> bool:
+        """Check if this region's character tags contains at least one tag from a list."""
+        return not self.character_tags or bool(set(self.character_tags) & set(tags))
+    
+    def has_option_tags(self, tags: List[str]) -> bool:
+        """Check if this region's option tags contains at least one tag from a list."""
+        return not self.option_tags or bool(set(self.option_tags) & set(tags))
 
 # Read items data from JSON
-# with open(os.path.join(os.path.dirname(__file__), 'data', 'locations.json'), 'r') as file:
-#     _locations_data = json.loads(file.read())
-
 _file_data = pkgutil.get_data(__name__, 'data/locations.json')
 _locations_data = json.loads(_file_data)
 
@@ -44,8 +48,9 @@ location_name_to_id_lookup: Dict[str, int] = {}
 
 # Get locations from JSON file
 for location in location_table:
-    for i in range(location.count):
-        loc_name: str = location.name.format(count=i+1)
+
+    for i in range(location.count_start, location.count_start + location.count * location.count_step, location.count_step):
+        loc_name: str = location.name.format(count=i)
         loc_id: str = _cur_loc_id
 
         # logging.info(f"Adding location lookup '{loc_name}': {loc_id}")

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -117,6 +117,10 @@ class CursedWordsOptions(PerGameCommonOptions):
 
         # logging.info(f"Playable Characters selection: {self.characters.value}")
 
+        # Revert to default if empty list provided
+        if len(self.characters.value) == 0:
+            self.characters.value = self.characters.default
+
         # Check if 'All' exists in Characters option
         if "All" in self.characters.value:
             # logging.info(f"  -> 'All' found, including all characters...")
@@ -124,6 +128,10 @@ class CursedWordsOptions(PerGameCommonOptions):
 
         # logging.info(f"Starting character selection: {self.starting_character.value}")
         
+        # Revert to default if empty list provided
+        if len(self.starting_character.value) == 0:
+            self.starting_character.value = self.starting_character.default  
+
         # Check if 'Random' exists in Starting Character option
         if "Random" in self.starting_character.value:
             # logging.info(f"  -> 'Random' found, selecting all characters from <Playable Characters> selection...")
@@ -138,6 +146,10 @@ class CursedWordsOptions(PerGameCommonOptions):
             self.starting_character.value = self.characters.value    
 
         # logging.info(f"Goal selection: {self.goal.value}")
+
+        # Revert to default if empty list provided
+        if len(self.goal.value) == 0:
+            self.goal.value = self.characters.default
 
         # Check if 'All' exists in Goal options
         if "All" in self.goal.value:

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -61,6 +61,14 @@ class ProgressiveGridSize(Toggle):
     display_name = "Progressive Grid Size"
     default = False
 
+class ProgressiveInventorySlots(Toggle):
+    """
+    Your inventory has all Sticker and Stamp Slots locked and cannot be used.
+    5x 'Progressive Sticker Slot' and 5x 'Progressive Stamp Slot' items are added to the item pool, each unlocking one respective slot.
+    """
+    display_name = "Progressive Inventory Slots"
+    default = False
+
 class ProgressiveTilePositions(Toggle):
     """
     The grid starts with 10 randomly selected tile positions being 'locked', making them un-selectable, and adds 10
@@ -104,6 +112,7 @@ class CursedWordsOptions(PerGameCommonOptions):
     goal: Goal
     deathlink: DeathLink
     progressive_grid_size: ProgressiveGridSize
+    progressive_inventory_slots: ProgressiveInventorySlots
     progressive_tile_positions: ProgressiveTilePositions
     shopsanity: Shopsanity
     shopsanity_location_count: ShopsanityLocationCount

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -77,6 +77,16 @@ class ShuffleLockedTilePositions(Toggle):
     display_name = "Shuffle Locked Tile Positions"
     default = False
 
+class Bosssanity(Toggle):
+    """
+    Add checks for defeating each individual main boss.
+    
+    NOTE: Does not currently include Sandy, Cretacious Meg, Human Boy, Beans or Michael.
+          Will be added in a future update.
+    """
+    display_name = "Boss-sanity"
+    default = False
+
 class Shopsanity(Toggle):
     """
     Add items to the shop that can be purchased to check locations.
@@ -114,6 +124,7 @@ class CursedWordsOptions(PerGameCommonOptions):
     shuffle_grid_size: ShuffleGridSize
     shuffle_inventory_slots: ShuffleInventorySlots
     shuffle_locked_tile_positions: ShuffleLockedTilePositions
+    bosssanity: Bosssanity
     shopsanity: Shopsanity
     shopsanity_limit: ShopsanityLimit
     shopsanity_cost: ShopsanityCost

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -3,7 +3,7 @@ from BaseClasses import ItemClassification, Options
 # from .Enums import GoalType
 from .Items import item_table
 import logging
-from Options import Choice, DeathLink, OptionDict, OptionList, ItemDict, PerGameCommonOptions, StartInventoryPool, Toggle
+from Options import Choice, DeathLink, OptionDict, OptionList, ItemDict, NumericOption, PerGameCommonOptions, StartInventoryPool, Toggle
 from .Regions import region_table
 from typing import Dict, List
 
@@ -53,6 +53,22 @@ class Goal(OptionList):
     valid_keys = [ "All" ] + _character_names
     default = [ "All" ]
 
+class ProgressiveGridSize(Toggle):
+    """
+    The grid starts as 3x3 tiles and adds two 'Progressive Grid Size' items to the pool, each increasing the grid size
+    to 4x4 and then 5x5 tiles.
+    """
+    display_name = "Progressive Grid Size"
+    default = False
+
+class ProgressiveTilePositions(Toggle):
+    """
+    The grid starts with 10 randomly selected tile positions being 'locked', making them un-selectable, and adds 10
+    'Progressive Tile Position' items to the pool, each unlocking one locked tile position.
+    """
+    display_name = "Progressive Tile Positions"
+    default = False
+
 @dataclass
 class CursedWordsOptions(PerGameCommonOptions):
     """"""
@@ -60,6 +76,8 @@ class CursedWordsOptions(PerGameCommonOptions):
     starting_character: StartingCharacter
     goal: Goal
     deathlink: DeathLink
+    progressive_grid_size: ProgressiveGridSize
+    progressive_tile_positions: ProgressiveTilePositions
 
     # Built-in
     start_inventory_from_pool: StartInventoryPool
@@ -89,7 +107,7 @@ class CursedWordsOptions(PerGameCommonOptions):
             # logging.info(f"  -> No matching characters selected, defaulting to 'Random'...")
             self.starting_character.value = self.characters.value    
 
-        logging.info(f"Goal selection: {self.goal.value}")
+        # logging.info(f"Goal selection: {self.goal.value}")
 
         # Check if 'All' exists in Goal options
         if "All" in self.goal.value:

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -53,28 +53,28 @@ class Goal(OptionList):
     valid_keys = [ "All" ] + _character_names
     default = [ "All" ]
 
-class ProgressiveGridSize(Toggle):
+class ShuffleGridSize(Toggle):
     """
     The grid starts as 3x3 tiles and adds two 'Progressive Grid Size' items to the pool, each increasing the grid size
     to 4x4 and then 5x5 tiles.
     """
-    display_name = "Progressive Grid Size"
+    display_name = "Shuffle Grid Size"
     default = False
 
-class ProgressiveInventorySlots(Toggle):
+class ShuffleInventorySlots(Toggle):
     """
     Your inventory has all Sticker and Stamp Slots locked and cannot be used.
     5x 'Progressive Sticker Slot' and 5x 'Progressive Stamp Slot' items are added to the item pool, each unlocking one respective slot.
     """
-    display_name = "Progressive Inventory Slots"
+    display_name = "Shuffle Inventory Slots"
     default = False
 
-class ProgressiveTilePositions(Toggle):
+class ShuffleLockedTilePositions(Toggle):
     """
-    The grid starts with 10 randomly selected tile positions being 'locked', making them un-selectable, and adds 10
-    'Progressive Tile Position' items to the pool, each unlocking one locked tile position.
+    The grid starts with 10 randomly selected tile positions being 'locked', making them un-selectable.
+    Adds 10 'Progressive Tile Position' items to the pool, each unlocking one locked tile position.
     """
-    display_name = "Progressive Tile Positions"
+    display_name = "Shuffle Locked Tile Positions"
     default = False
 
 class Shopsanity(Toggle):
@@ -84,22 +84,22 @@ class Shopsanity(Toggle):
     display_name = "Shopsanity"
     default = False
 
-class ShopsanityLocationCount(Range):
+class ShopsanityLimit(Range):
     """
-    How many shop locations will be available.
+    How many shop locations will be available for purchase.
     NOTE: This setting will be ignored if <shopsanity> is 'false'.
     """
-    display_name = "Shopsanity Location Count"
+    display_name = "Shopsanity Limit"
     range_start = 1
     range_end = 30
     default = 20
 
-class ShopsanityLocationCost(Range):
+class ShopsanityCost(Range):
     """
     How much each shop location will cost to purchase.
     NOTE: This setting is ignored if <shopsanity> is 'false'.
     """
-    display_name = "Shopsanity Location Cost"
+    display_name = "Shopsanity Cost"
     range_start = 5
     range_end = 25
     default = 12
@@ -111,12 +111,12 @@ class CursedWordsOptions(PerGameCommonOptions):
     starting_character: StartingCharacter
     goal: Goal
     deathlink: DeathLink
-    progressive_grid_size: ProgressiveGridSize
-    progressive_inventory_slots: ProgressiveInventorySlots
-    progressive_tile_positions: ProgressiveTilePositions
+    shuffle_grid_size: ShuffleGridSize
+    shuffle_inventory_slots: ShuffleInventorySlots
+    shuffle_locked_tile_positions: ShuffleLockedTilePositions
     shopsanity: Shopsanity
-    shopsanity_location_count: ShopsanityLocationCount
-    shopsanity_location_cost: ShopsanityLocationCost
+    shopsanity_limit: ShopsanityLimit
+    shopsanity_cost: ShopsanityCost
 
     # Built-in
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -69,6 +69,13 @@ class ProgressiveTilePositions(Toggle):
     display_name = "Progressive Tile Positions"
     default = False
 
+class Shopsanity(Toggle):
+    """
+    Add 20 shop locations (10 for Stickers, 10 for Stamps) that can be purchased from the shop.
+    """
+    display_name = "Shopsanity"
+    default = False
+
 @dataclass
 class CursedWordsOptions(PerGameCommonOptions):
     """"""
@@ -78,6 +85,7 @@ class CursedWordsOptions(PerGameCommonOptions):
     deathlink: DeathLink
     progressive_grid_size: ProgressiveGridSize
     progressive_tile_positions: ProgressiveTilePositions
+    shopsanity: Shopsanity
 
     # Built-in
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/cursed_words/Options.py
+++ b/worlds/cursed_words/Options.py
@@ -3,7 +3,7 @@ from BaseClasses import ItemClassification, Options
 # from .Enums import GoalType
 from .Items import item_table
 import logging
-from Options import Choice, DeathLink, OptionDict, OptionList, ItemDict, NumericOption, PerGameCommonOptions, StartInventoryPool, Toggle
+from Options import DeathLink, OptionList, PerGameCommonOptions, Range, StartInventoryPool, Toggle
 from .Regions import region_table
 from typing import Dict, List
 
@@ -71,10 +71,30 @@ class ProgressiveTilePositions(Toggle):
 
 class Shopsanity(Toggle):
     """
-    Add 20 shop locations (10 for Stickers, 10 for Stamps) that can be purchased from the shop.
+    Add items to the shop that can be purchased to check locations.
     """
     display_name = "Shopsanity"
     default = False
+
+class ShopsanityLocationCount(Range):
+    """
+    How many shop locations will be available.
+    NOTE: This setting will be ignored if <shopsanity> is 'false'.
+    """
+    display_name = "Shopsanity Location Count"
+    range_start = 1
+    range_end = 30
+    default = 20
+
+class ShopsanityLocationCost(Range):
+    """
+    How much each shop location will cost to purchase.
+    NOTE: This setting is ignored if <shopsanity> is 'false'.
+    """
+    display_name = "Shopsanity Location Cost"
+    range_start = 5
+    range_end = 25
+    default = 12
 
 @dataclass
 class CursedWordsOptions(PerGameCommonOptions):
@@ -86,6 +106,8 @@ class CursedWordsOptions(PerGameCommonOptions):
     progressive_grid_size: ProgressiveGridSize
     progressive_tile_positions: ProgressiveTilePositions
     shopsanity: Shopsanity
+    shopsanity_location_count: ShopsanityLocationCount
+    shopsanity_location_cost: ShopsanityLocationCost
 
     # Built-in
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/cursed_words/Regions.py
+++ b/worlds/cursed_words/Regions.py
@@ -11,37 +11,47 @@ class CursedWordsExit:
     """Data class for Cursed World exits from JSON configuration"""
     def __init__(self, json_data: Dict[any, any]):
         self.access_rule: Dict[str, any] = json_data.get("access_rule", None)
+        self.character_tags: str = json_data.get("character_tags", [])
         self.destination: str = json_data["destination"]
         self.include_for: List[str] = json_data.get("include_for", [])
         self.name: str = json_data.get("name")
-        self.tags: str = json_data.get("tags", [])
+        self.option_tags: str = json_data.get("option_tags", [])
         self.type: EntranceType = EntranceType(json_data.get("type", 2))
 
     def is_included(self, inclusions: List[str]) -> bool:
         """Check this exit against the world inclusions list to see if it should be included."""
         return not self.include_for or set(self.include_for).issubset(set(inclusions))
     
-    def has_tags(self, tags: List[str]) -> bool:
-        """Check if all of this exit's tags are present in a tags list"""
-        return set(self.tags).issubset(set(tags))
+    def has_character_tags(self, tags: List[str]) -> bool:
+        """Check if this exit's character tags contains at least one tag from a list."""
+        return not self.character_tags or bool(set(self.character_tags) & set(tags))
+    
+    def has_option_tags(self, tags: List[str]) -> bool:
+        """Check if this exit's option tags contains at least one tag from a list."""
+        return not self.option_tags or bool(set(self.option_tags) & set(tags))
 
 @dataclass
 class CursedWordsRegion:
     """Data class for Cursed World regions from JSON configuration"""
     def __init__(self, json_data: Dict[any, any]):
-        self.name: str = json_data["name"]
+        self.character_tags: List[str] = json_data.get("character_tags", [])
+        self.count: int = json_data.get("count", 1)
+        self.count_start: int = json_data.get("count_start", 1)
+        self.count_step: int = json_data.get("count_step", 1)
         self.exits: List[CursedWordsExit] = [ CursedWordsExit(entrance) for entrance in json_data.get("exits", []) ]
-        self.tags: List[str] = json_data.get("tags", [])
+        self.name: str = json_data["name"]
+        self.option_tags: List[str] = json_data.get("option_tags", [])
         # self.starting_inventory: List[str] = json_data.get("starting_inventory", [])
 
-    def has_tags(self, tags: List[str]) -> bool:
-        """Check if all of this region's tags are present in a tags list"""
-        return set(self.tags).issubset(set(tags))
+    def has_character_tags(self, tags: List[str]) -> bool:
+        """Check if this region's character tags contains at least one tag from a list."""
+        return not self.character_tags or bool(set(self.character_tags) & set(tags))
+    
+    def has_option_tags(self, tags: List[str]) -> bool:
+        """Check if this region's option tags contains at least one tag from a list."""
+        return not self.option_tags or bool(set(self.option_tags) & set(tags))
 
 # Read regions data from JSON
-# with open(os.path.join(os.path.dirname(__file__), 'data', 'regions.json'), 'r') as file:
-#     _regions_data = json.loads(file.read())
-
 _file_data = pkgutil.get_data(__name__, 'data/regions.json')
 _regions_data = json.loads(_file_data)
 
@@ -56,71 +66,85 @@ def generate_regions(world: World):
     # Get all regions with matching tags from configuration options
     enabled_regions: List[CursedWordsRegion] = [
         region for region in region_table
-        if region.has_tags(world.tags)
+        if region.has_character_tags(world.character_tags)
+        and region.has_option_tags(world.option_tags)
     ]
 
     # logging.info(f"Found {len(enabled_regions)} enabled regions based on configuration options")
 
     # First pass to create regions from region data models
     for region_model in enabled_regions:
-        # logging.info(f"  -> Creating region: {region_model.name}...")
 
-        # Create region
-        region: Region = Region(region_model.name, world.player, world.multiworld)
+        # Create regions
+        for i in range(region_model.count_start, region_model.count_start + region_model.count * region_model.count_step, region_model.count_step):
 
-        # Get enabled locations for region with matching tags from configuration options
-        enabled_locations: List[CursedWordsLocation] = [
-            location for location in location_table
-            if location.is_for_region(region.name) and location.has_tags(world.tags)
-        ]
+            region: Region = Region(region_model.name.format(count=i), world.player, world.multiworld)
 
-        # logging.info(f"  -> Found {len(enabled_locations)} enabled locations for region")
+            # logging.info(f"  -> Creating region: {region.name}")
 
-        # Create locations and add to region
-        for location_model in enabled_locations:
-            
-            # --- Intercept locations with specific counts defined ---
+            # Get enabled locations for region with matching tags from configuration options
+            enabled_locations: List[CursedWordsLocation] = [
+                location for location in location_table
+                if location.is_for_region(region.name)
+                and location.has_character_tags(world.character_tags)
+                and location.has_option_tags(world.option_tags)
+            ]
 
-            # If 'Shopsanity' is enabled, update the amount of shopsanity checks to include
-            if world.options.shopsanity.value and location_model.name.startswith("Shop Item "):
-                location_model.count = world.options.shopsanity_limit.value
+            # logging.info(f"  -> Found {len(enabled_locations)} enabled locations for region")
 
-            # --- End of Intercept ---
+            # Create locations and add to region
+            for location_model in enabled_locations:
+                
+                # --- Intercept locations with specific counts defined ---
 
-            for i in range(location_model.count):
-                loc_name: str = location_model.name.format(count=i+1)
-                loc_id: int = world.location_name_to_id[loc_name]
+                # If 'Shopsanity' is enabled, update the amount of shopsanity checks to include
+                if world.options.shopsanity.value and location_model.name.startswith("Shop: Buy Shopsanity Item "):
+                    location_model.count = world.options.shopsanity_limit.value
 
-                # logging.info(f"    -> Creating location: {loc_name} with ID {loc_id}...")
+                # --- End of Intercept ---
 
-                # Create location
-                location: Location = Location(world.player, loc_name, loc_id, region)
-                if location_model.access_rule:
-                    world.set_rule(location, world.rule_from_dict(location_model.access_rule))
+                for j in range(location_model.count_start, location_model.count_start + location_model.count * location_model.count_step, location_model.count_step):
+                    loc_name: str = location_model.name.format(count=j)
+                    loc_id: int = world.location_name_to_id[loc_name]
 
-                # Append to region
-                region.locations.append(location)
+                    # logging.info(f"    -> Creating location: {loc_name} with ID {loc_id}...")
 
-        # Append region to multiworld
-        world.multiworld.regions.append(region)
+                    # Create location
+                    location: Location = Location(world.player, loc_name, loc_id, region)
+                    if location_model.access_rule:
+                        world.set_rule(location, world.rule_from_dict(location_model.access_rule))
+
+                    # Append to region
+                    region.locations.append(location)
+
+            # Append region to multiworld
+            world.multiworld.regions.append(region)
 
     # Second pass to create and connect exits (regions have to exist in the multiworld first)
     for region_data in enabled_regions:
-        # Get region from multiworld
-        region: Region = world.multiworld.get_region(region_data.name, world.player)
 
-        for exit_model in [ exit for exit in region_data.exits if exit.has_tags(world.tags)]:
+        for i in range(region_data.count_start, region_data.count_start + region_data.count * region_data.count_step, region_data.count_step):
 
-            # logging.info(f"    -> Creating exit: {exit_model.name}")
-            exit: Entrance = Entrance(world.player, exit_model.name, region, randomization_type=exit_model.type)
+            # Get region from multiworld
+            region: Region = world.multiworld.get_region(region_data.name.format(count=i), world.player)
 
-            # Create access rule, if one exists
-            if exit_model.access_rule:
-                world.set_rule(exit, world.rule_from_dict(exit_model.access_rule))
+            for exit_model in [
+                exit for exit in region_data.exits
+                if exit.has_character_tags(world.character_tags)
+                and exit.has_option_tags(world.option_tags)
+            ]:
 
-            # Connect exit to destination region
-            destination_region: Region = world.multiworld.get_region(exit_model.destination, world.player)
-            exit.connect(destination_region)
+                # logging.info(f"    -> Creating exit: {exit_model.name}")
+                
+                exit: Entrance = Entrance(world.player, exit_model.name, region, randomization_type=exit_model.type)
 
-            # Append exit to region
-            region.exits.append(exit)
+                # Create access rule, if one exists
+                if exit_model.access_rule:
+                    world.set_rule(exit, world.rule_from_dict(exit_model.access_rule))
+
+                # Connect exit to destination region
+                destination_region: Region = world.multiworld.get_region(exit_model.destination, world.player)
+                exit.connect(destination_region)
+
+                # Append exit to region
+                region.exits.append(exit)

--- a/worlds/cursed_words/Regions.py
+++ b/worlds/cursed_words/Regions.py
@@ -2,8 +2,7 @@ from BaseClasses import Entrance, EntranceType, Location, MultiWorld, Region
 from dataclasses import dataclass
 import json, logging, os
 from .Locations import location_table, location_name_to_id_lookup, CursedWordsLocation
-# from .Options import CastNChillOptions
-# from .Rules import compile_access_rules
+import pkgutil
 from typing import Dict, List
 from worlds.AutoWorld import World
 
@@ -40,8 +39,11 @@ class CursedWordsRegion:
         return set(self.tags).issubset(set(tags))
 
 # Read regions data from JSON
-with open(os.path.join(os.path.dirname(__file__), 'data\\regions.json'), 'r') as file:
-    _regions_data = json.loads(file.read())
+# with open(os.path.join(os.path.dirname(__file__), 'data', 'regions.json'), 'r') as file:
+#     _regions_data = json.loads(file.read())
+
+_file_data = pkgutil.get_data(__name__, 'data/regions.json')
+_regions_data = json.loads(_file_data)
 
 # Parse as region objects
 region_table: List[CursedWordsRegion] = [ CursedWordsRegion(data) for data in _regions_data ]

--- a/worlds/cursed_words/Regions.py
+++ b/worlds/cursed_words/Regions.py
@@ -98,7 +98,7 @@ def generate_regions(world: World):
                 # --- Intercept locations with specific counts defined ---
 
                 # If 'Shopsanity' is enabled, update the amount of shopsanity checks to include
-                if world.options.shopsanity.value and location_model.name.startswith("Shop: Buy Shopsanity Item "):
+                if world.options.shopsanity.value and location_model.name.startswith("Buy Shopsanity Item "):
                     location_model.count = world.options.shopsanity_limit.value
 
                 # --- End of Intercept ---

--- a/worlds/cursed_words/Regions.py
+++ b/worlds/cursed_words/Regions.py
@@ -83,7 +83,7 @@ def generate_regions(world: World):
 
             # If 'Shopsanity' is enabled, update the amount of shopsanity checks to include
             if world.options.shopsanity.value and location_model.name.startswith("Shop Item "):
-                location_model.count = world.options.shopsanity_location_count.value
+                location_model.count = world.options.shopsanity_limit.value
 
             # --- End of Intercept ---
 

--- a/worlds/cursed_words/Regions.py
+++ b/worlds/cursed_words/Regions.py
@@ -78,6 +78,14 @@ def generate_regions(world: World):
 
         # Create locations and add to region
         for location_model in enabled_locations:
+            
+            # --- Intercept locations with specific counts defined ---
+
+            # If 'Shopsanity' is enabled, update the amount of shopsanity checks to include
+            if world.options.shopsanity.value and location_model.name.startswith("Shop Item "):
+                location_model.count = world.options.shopsanity_location_count.value
+
+            # --- End of Intercept ---
 
             for i in range(location_model.count):
                 loc_name: str = location_model.name.format(count=i+1)

--- a/worlds/cursed_words/Rules.py
+++ b/worlds/cursed_words/Rules.py
@@ -10,7 +10,7 @@ def generate_goal_events(world: World):
 
     for goal_character in world.options.goal.value:
 
-        region: Region = world.multiworld.get_region(f"{goal_character} - Stage 5", world.player)
+        region: Region = world.multiworld.get_region(f"{goal_character}: Stage 5", world.player)
 
         event: Location = Location(world.player, goal_character, None, region)
         event.place_locked_item(Item("Victory", ItemClassification.progression, None, world.player))

--- a/worlds/cursed_words/Rules.py
+++ b/worlds/cursed_words/Rules.py
@@ -5,21 +5,20 @@ from typing import Any, Dict, List
 from worlds.AutoWorld import World
 from worlds.generic.Rules import set_rule
 
-def generate_goal(world: World):
-    """Set the goal condition"""
+def generate_goal_events(world: World):
+    """Create goal event locations and items for each goal character."""
 
-    # Add events for each character's run completion
     for goal_character in world.options.goal.value:
 
         region: Region = world.multiworld.get_region(f"{goal_character} - Stage 5", world.player)
 
-        # logging.info(f"Creating goal location for region {region.name}")
-        
         event: Location = Location(world.player, goal_character, None, region)
         event.place_locked_item(Item("Victory", ItemClassification.progression, None, world.player))
-        
-        # Add goal event to character's final stage
+
         region.locations.append(event)
 
-    # Set rule to require victory event item
+
+def generate_goal(world: World):
+    """Set the goal completion rule."""
+
     world.set_completion_rule(Has("Victory", len(world.options.goal.value)))

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -48,9 +48,9 @@ class CursedWordsWorld(World):
         # Gather tags for run (determines what items/locations/regions to include in the run)
         self.tags: List[str] = [
             *self.options.characters.value,
-            *([self.options.progressive_grid_size.display_name] if self.options.progressive_grid_size.value else []),
-            *([self.options.progressive_inventory_slots.display_name] if self.options.progressive_inventory_slots.value else []),
-            *([self.options.progressive_tile_positions.display_name] if self.options.progressive_tile_positions.value else []),
+            *([self.options.shuffle_grid_size.display_name] if self.options.shuffle_grid_size.value else []),
+            *([self.options.shuffle_inventory_slots.display_name] if self.options.shuffle_inventory_slots.value else []),
+            *([self.options.shuffle_locked_tile_positions.display_name] if self.options.shuffle_locked_tile_positions.value else []),
             *([self.options.shopsanity.display_name] if self.options.shopsanity.value else []),
 
             # Additional tag inclusions go here...
@@ -72,7 +72,7 @@ class CursedWordsWorld(World):
 
         # If 'Progressive Tile Positions' is enabled, generate tile positions
         self.selected_tile_positions = []
-        if self.options.progressive_tile_positions.value:
+        if self.options.shuffle_locked_tile_positions.value:
             # To attempt to evenly spread locked tiles, split 5x5 grid into concentric 'L' shapes and randomly select
             # more from each larger 'L' shape - this should also mean a 3x3 starting grid from 'Progressive Grid Size'
             # will only ever contain 3 locked tile positions
@@ -114,14 +114,15 @@ class CursedWordsWorld(World):
         slot_data: Dict[str, any] = self.options.as_dict(
             "deathlink",
             "goal",
-            "progressive_grid_size",
-            "progressive_inventory_slots",
-            "shopsanity_location_count",
-            "shopsanity_location_cost",
+            "shuffle_grid_size",
+            "shuffle_inventory_slots",
+            "shuffle_locked_tile_positions",
+            "shopsanity_limit",
+            "shopsanity_cost",
         )
 
         slot_data.update({
-            "progressive_tile_positions": self.selected_tile_positions
+            "shuffle_locked_tile_positions_coords": self.selected_tile_positions
         })
 
         return slot_data

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -4,7 +4,7 @@ from .Items import CursedWordsItem, item_name_groups_lookup, item_name_to_id_loo
 from .Locations import location_name_to_id_lookup, location_table
 from .Options import CursedWordsOptions
 from .Regions import CursedWordsRegion, region_table, generate_regions
-from .Rules import generate_goal
+from .Rules import generate_goal_events, generate_goal
 import logging
 import math
 from typing import Any, Dict, List
@@ -63,8 +63,8 @@ class CursedWordsWorld(World):
 
         # logging.info(f"Randomly selected '{self.start_character}' as starting character")
 
-        # Add starting character as starting item from pool
-        self.options.start_inventory_from_pool.value = { f"{self.start_character}": 1 }
+        # Pre-collect starting character so it's always in the initial state
+        self.multiworld.push_precollected(self.create_item(self.start_character))
 
         # logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
 
@@ -92,11 +92,14 @@ class CursedWordsWorld(World):
     
     def create_filler(self):
         """Create a filler item - used when StartInventoryPool needs to fill a gap created by pre-collected items."""
+        if not hasattr(self, 'tags'):
+            self.tags = []
         return generate_filler_items(self, 1)[0]
 
     def create_regions(self):
         """Create all applicable regions for the configured multiworld."""
         generate_regions(self)
+        generate_goal_events(self)
 
     def set_rules(self):
          """Set access rules for regions, locations and goals."""

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -6,6 +6,7 @@ from .Options import CursedWordsOptions
 from .Regions import CursedWordsRegion, region_table, generate_regions
 from .Rules import generate_goal
 import logging
+import math
 from typing import Any, Dict, List
 
 class CursedWordsWeb(WebWorld):
@@ -46,23 +47,38 @@ class CursedWordsWorld(World):
 
         # Gather tags for run (determines what items/locations/regions to include in the run)
         self.tags: List[str] = [
-            *self.options.characters.value
+            *self.options.characters.value,
+            *([self.options.progressive_grid_size.display_name] if self.options.progressive_grid_size.value else []),
+            *([self.options.progressive_tile_positions.display_name] if self.options.progressive_tile_positions.value else [])
             # Additional tag inclusions go here...
         ]
 
-        logging.info(f"Selecting starting character ...")
+        # logging.info(f"Selecting starting character ...")
 
         # Randomly select starting character
         self.start_character: str = self.random.choice(
             self.options.starting_character.value
         )
 
-        logging.info(f"Randomly selected '{self.start_character}' as starting character")
+        # logging.info(f"Randomly selected '{self.start_character}' as starting character")
 
         # Add starting character as starting item from pool
         self.options.start_inventory_from_pool.value.update({ f"{self.start_character}": 1 })
 
-        logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
+        # logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
+
+        # If 'Progressive Tile Positions' is enabled
+        self.selected_tile_positions = []
+        if self.options.progressive_tile_positions.value:
+            # To attempt to evenly spread locked tiles, split 5x5 grid into concentric 'L' shapes and randomly select
+            # more from each larger 'L' shape - this should also mean a 3x3 starting grid from 'Progressive Grid Size'
+            # will only ever contain 3 locked tile positions
+            self.selected_tile_positions = (
+                self.random.sample([[0,1], [0,2], [1,1], [1,2]], 1) +
+                self.random.sample([[2,0], [2,1], [2,2], [1,2], [0,2]], 2) +
+                self.random.sample([[3,0], [3,1], [3,2], [3,3], [2,3], [1,3], [0,3]], 3) +
+                self.random.sample([[4,0], [4,1], [4,2], [4,3], [4,4], [3,4], [2,4], [1,4], [0,4]], 4)
+            )
 
     def create_items(self):
         """Create all items for the item pool."""
@@ -91,7 +107,12 @@ class CursedWordsWorld(World):
         # Add required options data
         slot_data: Dict[str, any] = self.options.as_dict(
             "deathlink",
-            "goal"
+            "goal",
+            "progressive_grid_size"
         )
+
+        slot_data.update({
+            "progressive_tile_positions": self.selected_tile_positions
+        })
 
         return slot_data

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -49,7 +49,8 @@ class CursedWordsWorld(World):
         self.tags: List[str] = [
             *self.options.characters.value,
             *([self.options.progressive_grid_size.display_name] if self.options.progressive_grid_size.value else []),
-            *([self.options.progressive_tile_positions.display_name] if self.options.progressive_tile_positions.value else [])
+            *([self.options.progressive_tile_positions.display_name] if self.options.progressive_tile_positions.value else []),
+            *([self.options.shopsanity.display_name] if self.options.shopsanity.value else [])
             # Additional tag inclusions go here...
         ]
 

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -64,7 +64,7 @@ class CursedWordsWorld(World):
         # logging.info(f"Randomly selected '{self.start_character}' as starting character")
 
         # Add starting character as starting item from pool
-        self.options.start_inventory_from_pool.value.update({ f"{self.start_character}": 1 })
+        self.options.start_inventory_from_pool.value = { f"{self.start_character}": 1 }
 
         # logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
 

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -46,14 +46,16 @@ class CursedWordsWorld(World):
         self.options.resolve_options()
 
         # Gather tags for run (determines what items/locations/regions to include in the run)
-        self.tags: List[str] = [
-            *self.options.characters.value,
+        self.character_tags: List[str] = [
+            *self.options.characters.value
+        ]
+
+        self.option_tags: List[str] = [
             *([self.options.shuffle_grid_size.display_name] if self.options.shuffle_grid_size.value else []),
             *([self.options.shuffle_inventory_slots.display_name] if self.options.shuffle_inventory_slots.value else []),
             *([self.options.shuffle_locked_tile_positions.display_name] if self.options.shuffle_locked_tile_positions.value else []),
             *([self.options.shopsanity.display_name] if self.options.shopsanity.value else []),
-
-            # Additional tag inclusions go here...
+            # Additional tag inclusions go here
         ]
 
         # logging.info(f"Selecting starting character ...")
@@ -67,6 +69,26 @@ class CursedWordsWorld(World):
 
         # Pre-collect starting character so it's always in the initial state
         self.multiworld.push_precollected(self.create_item(self.start_character))
+        
+        # Pre-collect 8 generic starting stamps
+        eligible_starting_stamps: List[str] = [
+            stamp.name for stamp in item_table
+            if len(stamp.character_tags) == 0
+            and len(stamp.option_tags) == 0
+            and "Stamps" in stamp.groups
+        ]
+        for stamp in self.random.sample(eligible_starting_stamps, 8):
+            self.multiworld.push_precollected(self.create_item(stamp))
+
+        # Pre-collect 8 generic starting stickers
+        eligible_starting_stickers: List[str] = [
+            sticker.name for sticker in item_table
+            if len(sticker.character_tags) == 0
+            and len(sticker.option_tags) == 0
+            and "Stickers" in sticker.groups
+        ]
+        for sticker in self.random.sample(eligible_starting_stickers, 8):
+            self.multiworld.push_precollected(self.create_item(sticker))
 
         # logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
 
@@ -117,7 +139,7 @@ class CursedWordsWorld(World):
             "shuffle_grid_size",
             "shuffle_inventory_slots",
             "shuffle_locked_tile_positions",
-            "shopsanity_limit",
+            "shopsanity",
             "shopsanity_cost",
         )
 

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -1,7 +1,7 @@
 from worlds.AutoWorld import World, WebWorld
 from BaseClasses import Item, ItemClassification, Tutorial
 from .Items import CursedWordsItem, item_name_groups_lookup, item_name_to_id_lookup, item_table, generate_items, generate_filler_items
-from .Locations import location_name_to_id_lookup
+from .Locations import location_name_to_id_lookup, location_table
 from .Options import CursedWordsOptions
 from .Regions import CursedWordsRegion, region_table, generate_regions
 from .Rules import generate_goal
@@ -68,7 +68,7 @@ class CursedWordsWorld(World):
 
         # logging.info(f"Starting inventory from pool: {self.options.start_inventory_from_pool.value}")
 
-        # If 'Progressive Tile Positions' is enabled
+        # If 'Progressive Tile Positions' is enabled, generate tile positions
         self.selected_tile_positions = []
         if self.options.progressive_tile_positions.value:
             # To attempt to evenly spread locked tiles, split 5x5 grid into concentric 'L' shapes and randomly select
@@ -109,7 +109,9 @@ class CursedWordsWorld(World):
         slot_data: Dict[str, any] = self.options.as_dict(
             "deathlink",
             "goal",
-            "progressive_grid_size"
+            "progressive_grid_size",
+            "shopsanity_location_count",
+            "shopsanity_location_cost"
         )
 
         slot_data.update({

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -49,8 +49,10 @@ class CursedWordsWorld(World):
         self.tags: List[str] = [
             *self.options.characters.value,
             *([self.options.progressive_grid_size.display_name] if self.options.progressive_grid_size.value else []),
+            *([self.options.progressive_inventory_slots.display_name] if self.options.progressive_inventory_slots.value else []),
             *([self.options.progressive_tile_positions.display_name] if self.options.progressive_tile_positions.value else []),
-            *([self.options.shopsanity.display_name] if self.options.shopsanity.value else [])
+            *([self.options.shopsanity.display_name] if self.options.shopsanity.value else []),
+
             # Additional tag inclusions go here...
         ]
 
@@ -113,8 +115,9 @@ class CursedWordsWorld(World):
             "deathlink",
             "goal",
             "progressive_grid_size",
+            "progressive_inventory_slots",
             "shopsanity_location_count",
-            "shopsanity_location_cost"
+            "shopsanity_location_cost",
         )
 
         slot_data.update({

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -54,6 +54,7 @@ class CursedWordsWorld(World):
             *([self.options.shuffle_grid_size.display_name] if self.options.shuffle_grid_size.value else []),
             *([self.options.shuffle_inventory_slots.display_name] if self.options.shuffle_inventory_slots.value else []),
             *([self.options.shuffle_locked_tile_positions.display_name] if self.options.shuffle_locked_tile_positions.value else []),
+            *([self.options.bosssanity.display_name] if self.options.bosssanity.value else []),
             *([self.options.shopsanity.display_name] if self.options.shopsanity.value else []),
             # Additional tag inclusions go here
         ]

--- a/worlds/cursed_words/__init__.py
+++ b/worlds/cursed_words/__init__.py
@@ -74,7 +74,7 @@ class CursedWordsWorld(World):
             # more from each larger 'L' shape - this should also mean a 3x3 starting grid from 'Progressive Grid Size'
             # will only ever contain 3 locked tile positions
             self.selected_tile_positions = (
-                self.random.sample([[0,1], [0,2], [1,1], [1,2]], 1) +
+                self.random.sample([[0,0], [0,1], [1,0], [1,1]], 1) +
                 self.random.sample([[2,0], [2,1], [2,2], [1,2], [0,2]], 2) +
                 self.random.sample([[3,0], [3,1], [3,2], [3,3], [2,3], [1,3], [0,3]], 3) +
                 self.random.sample([[4,0], [4,1], [4,2], [4,3], [4,4], [3,4], [2,4], [1,4], [0,4]], 4)

--- a/worlds/cursed_words/archipelago.json
+++ b/worlds/cursed_words/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Cursed Words",
     "minimum_ap_version": "0.6.7",
-    "world_version": "0.2.0",
+    "world_version": "0.3.0",
     "authors": ["JammyGeeza"]
 }

--- a/worlds/cursed_words/archipelago.json
+++ b/worlds/cursed_words/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Cursed Words",
     "minimum_ap_version": "0.6.7",
-    "world_version": "0.0.0",
+    "world_version": "0.2.0",
     "authors": ["JammyGeeza"]
 }

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -216,5 +216,17 @@
         "name": "$3",
         "classification": 0,
         "groups": [ "Money" ]
+    },
+    {
+        "name": "Consumable Tile",
+        "classification": 0
+    },
+    {
+        "name": "Extra Re-roll",
+        "classification": 0
+    },
+    {
+        "name": "Random Tile Boost",
+        "classification": 0
     }
 ]

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -71,6 +71,11 @@
         "groups": [ "Stamp Bundles" ]
     },
     {
+        "name": "Scatter Stamps",
+        "classification": 1,
+        "groups": [ "Stamp Bundles" ]
+    },
+    {
         "name": "Shiny Stamps",
         "classification": 1,
         "groups": [ "Stamp Bundles" ]
@@ -112,6 +117,11 @@
     },
     {
         "name": "Red Stickers",
+        "classification": 1,
+        "groups": [ "Sticker Bundles" ]
+    },
+    {
+        "name": "Scatter Stickers",
         "classification": 1,
         "groups": [ "Sticker Bundles" ]
     },

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -197,13 +197,15 @@
         "count": 5,
         "name": "Progressive Sticker Slot",
         "classification": 1,
-        "groups": [ "Sticker Slots" ]
+        "groups": [ "Sticker Slots" ],
+        "tags": [ "Progressive Inventory Slots" ]
     },
     {
         "count": 5,
         "name": "Progressive Stamp Slot",
         "classification": 1,
-        "groups": [ "Stamp Slots" ]
+        "groups": [ "Stamp Slots" ],
+        "tags": [ "Progressive Inventory Slots" ]
     },
     {
         "count": 10,

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -3,182 +3,37 @@
         "name": "Rodman",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Rodman" ]
+        "character_tags": [ "Rodman" ]
     },
     {
         "name": "Nina Nix",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Nina Nix" ]
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "name": "Hayley Bayles",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Hayley Bayles" ]
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "name": "Bones the Dog",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Bones the Dog" ]
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "name": "Sam Gambit",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Sam Gambit" ]
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "name": "Octacles",
         "classification": 1,
         "groups": [ "Characters" ],
-        "tags": [ "Octacles" ]
-    },
-    {
-        "name": "Blue Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Card Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Chess Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Cursed Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Number Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Rainbow Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Red Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Scatter Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Shiny Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Void Stamps",
-        "classification": 1,
-        "groups": [ "Stamp Bundles" ]
-    },
-    {
-        "name": "Blue Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Card Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Chess Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Cursed Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Number Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Rainbow Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Red Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Scatter Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Shiny Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Void Stickers",
-        "classification": 1,
-        "groups": [ "Sticker Bundles" ]
-    },
-    {
-        "name": "Blue Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Card Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Chess Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Currency Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Fraction Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Number Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Red Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Shiny Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
-    },
-    {
-        "name": "Void Tiles",
-        "classification": 1,
-        "groups": [ "Tiles" ]
+        "character_tags": [ "Octacles" ]
     },
     {
         "count": 5,
@@ -191,28 +46,28 @@
         "name": "Progressive Grid Size",
         "classification": 1,
         "groups": [ "Grid Sizes" ],
-        "tags": [ "Shuffle Grid Size" ]
+        "option_tags": [ "Shuffle Grid Size" ]
     },
     {
         "count": 5,
         "name": "Progressive Sticker Slot",
         "classification": 1,
         "groups": [ "Sticker Slots" ],
-        "tags": [ "Shuffle Inventory Slots" ]
+        "option_tags": [ "Shuffle Inventory Slots" ]
     },
     {
         "count": 5,
         "name": "Progressive Stamp Slot",
         "classification": 1,
         "groups": [ "Stamp Slots" ],
-        "tags": [ "Shuffle Inventory Slots" ]
+        "option_tags": [ "Shuffle Inventory Slots" ]
     },
     {
         "count": 10,
         "name": "Progressive Tile Position",
         "classification": 1,
         "groups": [ "Tile Positions" ],
-        "tags": [ "Shuffle Locked Tile Positions" ]
+        "option_tags": [ "Shuffle Locked Tile Positions" ]
     },
     {
         "name": "$1",
@@ -240,5 +95,887 @@
     {
         "name": "Random Tile Boost",
         "classification": 0
+    },
+
+
+    {
+        "name": "April Shower",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Artist's Palette",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring", "Red Scoring", "Shiny Scoring", "Void Scoring" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Blueberries",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Chequered Flag",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Cherries",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Cherry Pie",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Build" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Chips",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Credit Card",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Dusty Coffin",
+        "classification": 1,
+        "groups": [ "Stickers", "Void Scoring" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Egg",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Electric Guitar",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Fire Extinguisher",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Fountain",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Glass of Milk",
+        "classification": 1,
+        "groups": [ "Stickers", "? Scoring", "Cursed Scoring" ],
+        "character_tags": [ "Rodman", "Octacles" ]
+    },
+    {
+        "name": "Graduation Cap",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Ham Sandwich",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Hi Vis Jacket",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Lipstick",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Lucky Scarf",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Magic Wand",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring", "Red Scoring", "Shiny Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Maple Leaf",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Ornate Key",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring", "Red Scoring", "Shiny Scoring", "Void Scoring" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Pair of Socks",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Pneumonia",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Sequoia Sapking",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Sly Spy",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Stilton",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Sunflower",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Telescope",
+        "classification": 1,
+        "groups": [ "Stickers", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Wheezy Vixen",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Worn-out Jeans",
+        "classification": 1,
+        "groups": [ "Stickers", "? Scattering", "Blue Scoring", "Cursed Scattering" ],
+        "character_tags": [ "Rodman", "Octacles" ]
+    },
+    {
+        "name": "Yellow Glasses",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+
+    {
+        "name": "Mystery Gift",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Hungry Hippo",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Sushi",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Ambulance",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Dartboard",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Magic 8 Ball",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scoring" ],
+        "character_tags": [ "Sam Gambit" ]
+    },
+    {
+        "name": "Wind Chime",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Michael's Book",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+    {
+        "name": "Luffing Jib Crane",
+        "classification": 1,
+        "groups": [ "Stickers"]
+    },
+    {
+        "name": "Base Camp",
+        "classification": 1,
+        "groups": [ "Stickers" ]
+    },
+
+
+    {
+        "name": "Deep Sea Horror",
+        "classification": 1,
+        "groups": [ "Stickers", "Void Scoring" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Doughnut",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring", "Red Scoring", "Shiny Scoring", "Void Scoring" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Ferris Wheel",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scoring", "Red Scoring", "Shiny Scoring", "Void Scoring" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Fish Cake",
+        "classification": 1,
+        "groups": [ "Stickers", "Shiny Scoring" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Game Pad",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Red Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Jigsaw Piece",
+        "classification": 1,
+        "groups": [ "Stickers", "Void Scoring" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Maracas",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Rainbow Sprinkles",
+        "classification": 1,
+        "groups": [ "Stickers", "Shiny Scattering" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Tombstone",
+        "classification": 1,
+        "groups": [ "Stickers", "Void Scoring" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+
+
+    {
+        "name": "Alembic Flask",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Birthday Cake",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Boomerang",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Brain",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Lab Coat",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Ladybird",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scattering", "Red Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix", "Hayley Bayles" ]
+    },
+    {
+        "name": "Lucky Dice",
+        "classification": 1,
+        "groups": [ "Stickers", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Petri Dish",
+        "classification": 1,
+        "groups": [ "Stickers", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Soaring Kite",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Rodman", "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Ten Pin Bowling",
+        "classification": 1,
+        "groups": [ "Stickers", "Cursed Scattering", "Number Scattering", "Void Scattering" ],
+        "character_tags": [ "Nina Nix", "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Traffic Lights",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Cursed Scattering", "Number Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix", "Hayley Bayles", "Octacles" ]
+    },
+
+
+    {
+        "name": "Backpack",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scattering", "Cursed Scattering", "Red Scattering" ],
+        "character_tags": [ "Rodman", "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Carousel Horse",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Clapper Board",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scoring" ],
+        "character_tags": [ "Sam Gambit" ]
+    },
+    {
+        "name": "Gorilla",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scattering", "Cursed Scattering", "Void Scattering" ],
+        "character_tags": [ "Nina Nix", "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Movie Camera",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scoring" ],
+        "character_tags": [ "Sam Gambit" ]
+    },
+    {
+        "name": "Raccoon",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Suitcase",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Chess Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Rodman", "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Zebra",
+        "classification": 1,
+        "groups": [ "Stickers", "Chess Scoring" ],
+        "character_tags": [ "Sam Gambit" ]
+    },
+
+
+    {
+        "name": "Celestial Body",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Hanafuda",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Joker",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Kadomatsu",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Musical Notes",
+        "classification": 1,
+        "groups": [ "Stickers", "Blue Scattering", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Rodman", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Peacock",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Pear",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Peas Of A Pod",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Poker Face",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring", "Chess Scoring" ],
+        "character_tags": [ "Sam Gambit", "Bones the Dog" ]
+    },
+    {
+        "name": "Postal Horn",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Slide",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Wrestlers",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+
+
+    {
+        "name": "Amphora",
+        "classification": 1,
+        "groups": [ "Stickers", "Cursed Scattering" ],
+        "character_tags": [ "Octacles" ]
+    },
+    {
+        "name": "Broom",
+        "classification": 1,
+        "groups": [ "Stickers", "Cursed Scoring" ],
+        "character_tags": [ "Octacles" ]
+    },
+    {
+        "name": "Ghost",
+        "classification": 1,
+        "groups": [ "Stickers", "Cursed Scattering" ],
+        "character_tags": [ "Octacles" ]
+    },
+    {
+        "name": "Jack-o'-Lantern",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring", "Cursed Scoring", "Chess Scoring", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles", "Sam Gambit", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Mischievous Imp",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring", "Cursed Scoring", "Chess Scoring", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles", "Sam Gambit", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Moai",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring", "Cursed Scoring", "Chess Scoring", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles", "Sam Gambit", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Mysterious Amulet",
+        "classification": 1,
+        "groups": [ "Stickers", "Card Scoring", "Cursed Scoring", "Chess Scoring", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles", "Sam Gambit", "Bones the Dog", "Octacles" ]
+    },
+
+
+    {
+        "name": "Avocado",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Bento Box",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Bubble Tea",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Downward Trending Chart",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Efficient Recycler",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Family Ticket",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Full Moon",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Golden Record",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Golden Scales",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Hungry Snake",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Kimono",
+        "classification": 1,
+        "groups": [ "Stamps", "? Scattering", "Blue Scoring", "Cursed Scattering" ],
+        "character_tags": [ "Rodman", "Octacles" ]
+    },
+    {
+        "name": "Limnophila",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Nest Egg",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Paper Lantern",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Parachute",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Piñata",
+        "classification": 1,
+        "groups": [ "Stamps", "Shiny Scattering" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Queenie",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Red Envelope",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Saxophone",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Slot Machine",
+        "classification": 1,
+        "groups": [ "Stamps", "Void Scattering" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Sluggish Zombie",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Teapot",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Tile Ninja",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Waxy Vizor",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Weekly Shop",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Window",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Xray",
+        "classification": 1,
+        "groups": [ "Stamps", "? Scattering", "Blue Scoring", "Cursed Scattering" ],
+        "character_tags": [ "Rodman", "Octacles" ]
+    },
+    {
+        "name": "Young Cardinal",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+
+
+    {
+        "name": "Banana",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Head Trauma",
+        "classification": 1,
+        "groups": [ "Stamps", "? Scattering", "Blue Scattering", "Cursed Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix", "Octacles" ]
+    },
+    {
+        "name": "Busy Schedule",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Number Go Up",
+        "classification": 1,
+        "groups": [ "Stamps", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles" ]
+    },
+    {
+        "name": "Bar of Soap",
+        "classification": 1,
+        "groups": [ "Stamps", "? Scattering", "Cursed Scattering", "Shiny Scattering" ],
+        "character_tags": [ "Nina Nix", "Octacles" ]
+    },
+    {
+        "name": "Honeypot",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Ruler",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Christmas Tree",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Juice Box",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Chick",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Spicy Pepper",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scoring" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Rosebud",
+        "classification": 1,
+        "groups": [ "Stamps", "Red Scattering" ],
+        "character_tags": [ "Rodman" ]
+    },
+    {
+        "name": "Angel Investment",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Eraser",
+        "classification": 1,
+        "groups": [ "Stamps" ]
+    },
+    {
+        "name": "Tin of Beans",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+
+
+    {
+        "name": "Chocolate Candy",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+    {
+        "name": "Dangerous Summit",
+        "classification": 1,
+        "groups": [ "Stamps", "Void Scattering" ],
+        "character_tags": [ "Nina Nix" ]
+    },
+    {
+        "name": "Dango",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scoring", "Red Scoring", "Shiny Scoring", "Void Scoring" ],
+        "character_tags": [ "Rodman", "Nina Nix" ]
+    },
+
+
+    {
+        "name": "Flamingo",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Number Scattering", "Shiny Scoring"  ],
+        "character_tags": [ "Nina Nix", "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Full Battery",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scoring", "Number Scoring" ],
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Microscope",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
+    },
+    {
+        "name": "Test Tube",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
+    },
+
+
+    {
+        "name": "Business Goose",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Chess Scattering" ],
+        "character_tags": [ "Sam Gambit", "Octacles" ]
+    },
+    {
+        "name": "Queen Bee",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scattering", "Chess Scattering" ],
+        "character_tags": [ "Sam Gambit", "Octacles" ]
+    },
+
+    {
+        "name": "Card Shark",
+        "classification": 1,
+        "groups": [ "Stamps", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Four Leaf Clover",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Card Scattering", "Cursed Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Go Fish!",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Card Scattering", "Cursed Scattering", "Number Scattering" ],
+        "character_tags": [ "Rodman", "Hayley Bayles", "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Magician's Hat",
+        "classification": 1,
+        "groups": [ "Stamps", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Martini",
+        "classification": 1,
+        "groups": [ "Stamps", "Card Scoring" ],
+        "character_tags": [ "Bones the Dog" ]
+    },
+    {
+        "name": "Smart Shirt",
+        "classification": 1,
+        "groups": [ "Stamps", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Valentine's Day Card",
+        "classification": 1,
+        "groups": [ "Stamps", "Card Scattering", "Cursed Scattering" ],
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+
+    {
+        "name": "Haunted Mirror",
+        "classification": 1,
+        "groups": [ "Stamps", "Blue Scattering", "Cursed Scattering", "Red Scattering", "Shiny Scattering", "Void Scattering" ],
+        "character_tags": [ "Rodman", "Nina Nix", "Octacles" ]
+    },
+    {
+        "name": "Oden",
+        "classification": 1,
+        "groups": [ "Stamps", "Cursed Scoring" ],
+        "character_tags": [ "Octacles" ]
     }
 ]

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -172,6 +172,19 @@
     },
     {
         "count": 5,
+        "name": "Progressive Encounter Re-roll",
+        "classification": 2,
+        "groups": [ "Rerolls" ]
+    },
+    {
+        "count": 2,
+        "name": "Progressive Grid Size",
+        "classification": 1,
+        "groups": [ "Grid Sizes" ],
+        "tags": [ "Progressive Grid Size" ]
+    },
+    {
+        "count": 5,
         "name": "Progressive Sticker Slot",
         "classification": 1,
         "groups": [ "Sticker Slots" ]
@@ -183,10 +196,11 @@
         "groups": [ "Stamp Slots" ]
     },
     {
-        "count": 5,
-        "name": "Progressive Grid Re-roll",
-        "classification": 2,
-        "groups": [ "Rerolls" ]
+        "count": 10,
+        "name": "Progressive Tile Position",
+        "classification": 1,
+        "groups": [ "Tile Positions" ],
+        "tags": [ "Progressive Tile Positions" ]
     },
     {
         "name": "$1",

--- a/worlds/cursed_words/data/items.json
+++ b/worlds/cursed_words/data/items.json
@@ -191,28 +191,28 @@
         "name": "Progressive Grid Size",
         "classification": 1,
         "groups": [ "Grid Sizes" ],
-        "tags": [ "Progressive Grid Size" ]
+        "tags": [ "Shuffle Grid Size" ]
     },
     {
         "count": 5,
         "name": "Progressive Sticker Slot",
         "classification": 1,
         "groups": [ "Sticker Slots" ],
-        "tags": [ "Progressive Inventory Slots" ]
+        "tags": [ "Shuffle Inventory Slots" ]
     },
     {
         "count": 5,
         "name": "Progressive Stamp Slot",
         "classification": 1,
         "groups": [ "Stamp Slots" ],
-        "tags": [ "Progressive Inventory Slots" ]
+        "tags": [ "Shuffle Inventory Slots" ]
     },
     {
         "count": 10,
         "name": "Progressive Tile Position",
         "classification": 1,
         "groups": [ "Tile Positions" ],
-        "tags": [ "Progressive Tile Positions" ]
+        "tags": [ "Shuffle Locked Tile Positions" ]
     },
     {
         "name": "$1",

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -220,10 +220,18 @@
         "region": "Shop",
         "access_rule": {
             "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
             "args" : {
                 "item_name_group": "Sticker Slots",
                 "count": 1
-            }
+            },
+            "filtered_resolution": true
         }
     },
     {
@@ -231,10 +239,18 @@
         "region": "Shop",
         "access_rule": {
             "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
             "args" : {
                 "item_name_group": "Stamp Slots",
                 "count": 1
-            }
+            },
+            "filtered_resolution": true
         }
     },
     {
@@ -262,10 +278,18 @@
         "region": "Shop",
         "access_rule": {
             "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
             "args" : {
                 "item_name_group": "Sticker Slots",
                 "count": 1
-            }
+            },
+            "filtered_resolution": true
         }
     },
     {
@@ -273,10 +297,18 @@
         "region": "Shop",
         "access_rule": {
             "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
             "args" : {
                 "item_name_group": "Stamp Slots",
                 "count": 1
-            }
+            },
+            "filtered_resolution": true
         }
     },
     {
@@ -288,17 +320,33 @@
             "children": [
                 {
                     "rule": "HasGroup",
+                    "options": [
+                        {
+                            "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                            "value": 1,
+                            "operator": "eq"
+                        }
+                    ],
                     "args": {
                         "item_name_group": "Stamp Slots",
                         "count": 1
-                    }
+                    },
+                    "filtered_resolution": true
                 },
                 {
                     "rule": "HasGroup",
+                    "options": [
+                        {
+                            "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                            "value": 1,
+                            "operator": "eq"
+                        }
+                    ],
                     "args": {
                         "item_name_group": "Sticker Slots",
                         "count": 1
-                    }
+                    },
+                    "filtered_resolution": true
                 }
             ]
         },

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -610,5 +610,81 @@
             ]
         },
         "character_tags": [ "Nina Nix" ]
+    },
+
+    {
+        "name": "Defeat Axolotl",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Badger",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Bat",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Bison",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Capybara",
+        "region": "Stage 2",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Cobra",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Fox",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Hyena",
+        "region": "Stage 2",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Mole",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Robo-Eel",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Robo-Monkey",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Salamander",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Toothed Whale",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Wolf",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
+    },
+    {
+        "name": "Defeat Yeti Crab",
+        "region": "Stage 1",
+        "option_tags": [ "Boss-sanity" ]
     }
 ]

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -222,7 +222,7 @@
             "rule": "HasGroup",
             "options": [
                 {
-                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                     "value": 1,
                     "operator": "eq"
                 }
@@ -241,7 +241,7 @@
             "rule": "HasGroup",
             "options": [
                 {
-                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                     "value": 1,
                     "operator": "eq"
                 }
@@ -280,7 +280,7 @@
             "rule": "HasGroup",
             "options": [
                 {
-                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                     "value": 1,
                     "operator": "eq"
                 }
@@ -299,7 +299,7 @@
             "rule": "HasGroup",
             "options": [
                 {
-                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                     "value": 1,
                     "operator": "eq"
                 }
@@ -322,7 +322,7 @@
                     "rule": "HasGroup",
                     "options": [
                         {
-                            "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                            "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                             "value": 1,
                             "operator": "eq"
                         }
@@ -337,7 +337,7 @@
                     "rule": "HasGroup",
                     "options": [
                         {
-                            "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                            "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                             "value": 1,
                             "operator": "eq"
                         }
@@ -371,10 +371,18 @@
     },
     {
         "name": "Word Length 9",
-        "region": "Words High"
+        "region": "Words Medium"
     },
     {
         "name": "Word Length 10",
+        "region": "Words High"
+    },
+    {
+        "name": "Word Length 11",
+        "region": "Words High"
+    },
+    {
+        "name": "Word Length 12",
         "region": "Words High"
     },
     {
@@ -415,6 +423,10 @@
     },
     {
         "name": "Word Score > 1000",
+        "region": "Words High"
+    },
+    {
+        "name": "Word Score > 1500",
         "region": "Words High"
     }
 ]

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -182,56 +182,56 @@
 
 
     {
-        "name": "Run: Destroy a Consumable Tile",
+        "name": "Destroy a Consumable Tile",
         "region": "Stage 1"
     },
     {
         "count": 3,
         "count_start": 5,
         "count_step": 5,
-        "name": "Run: Earn ${count} Total",
+        "name": "Earn ${count} in a Run",
         "region": "Stage 1"
     },
     {
         "count": 4,
         "count_start": 20,
         "count_step": 10,
-        "name": "Run: Earn ${count} Total",
+        "name": "Earn ${count} in a Run",
         "region": "Stage 2"
     },
     {
         "count": 8,
         "count_start": 75,
         "count_step": 25,
-        "name": "Run: Earn ${count} Total",
+        "name": "Earn ${count} in a Run",
         "region": "Stage 3"
     },
     {
         "count": 5,
         "count_start": 300,
         "count_step": 50,
-        "name": "Run: Earn ${count} Total",
+        "name": "Earn ${count} in a Run",
         "region": "Stage 4"
     },
     {
         "count": 5,
         "count_start": 600,
-        "count_step": 10,
-        "name": "Run: Earn ${count} Total",
+        "count_step": 100,
+        "name": "Earn ${count} in a Run",
         "region": "Stage 5"
     },
     {
-        "name": "Run: Place a Consumable Tile",
+        "name": "Place a Consumable Tile",
         "region": "Stage 1"
     },
     {
-        "name": "Run: Skip a Grid",
+        "name": "Skip a Grid",
         "region": "Stage 1"
     },
 
 
     {
-        "name": "Shop: Buy a Sticker",
+        "name": "Buy a Sticker",
         "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
@@ -250,7 +250,7 @@
         }
     },
     {
-        "name": "Shop: Buy a Stamp",
+        "name": "Buy a Stamp",
         "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
@@ -269,12 +269,12 @@
         }
     },
     {
-        "name": "Shop: Buy a Consumable Tile",
+        "name": "Buy a Consumable Tile",
         "region": "Stage 1"
     },
     {
         "count": 30,
-        "name": "Shop: Buy Shopsanity Item {count}",
+        "name": "Buy Shopsanity Item {count}",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -314,19 +314,19 @@
         "option_tags": [ "Shopsanity" ]
     },
     {
-        "name": "Shop: Freeze a Stamp",
+        "name": "Freeze a Stamp",
         "region": "Stage 1"
     },
     {
-        "name": "Shop: Freeze a Sticker",
+        "name": "Freeze a Sticker",
         "region": "Stage 1"
     },
     {
-        "name": "Shop: Restock the Shop",
+        "name": "Restock the Shop",
         "region": "Stage 1"
     },
     {
-        "name": "Shop: Sell a Sticker",
+        "name": "Sell a Sticker",
         "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
@@ -345,7 +345,7 @@
         }
     },
     {
-        "name": "Shop: Sell a Stamp",
+        "name": "Sell a Stamp",
         "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
@@ -367,25 +367,25 @@
     
     {
         "count": 3,
-        "name": "Word: Length {count} Tiles",
+        "name": "Word Length: {count} Tiles",
         "region": "Stage 1"
     },
     {
         "count": 3,
         "count_start": 4,
-        "name": "Word: Length {count} Tiles",
+        "name": "Word Length: {count} Tiles",
         "region": "Stage 2"
     },
     {
         "count": 3,
         "count_start": 7,
-        "name": "Word: Length {count} Tiles",
+        "name": "Word Length: {count} Tiles",
         "region": "Stage 3"
     },
     {
         "count": 3,
         "count_start": 10,
-        "name": "Word: Length {count} Tiles",
+        "name": "Word Length: {count} Tiles",
         "region": "Stage 4"
     },
 
@@ -394,48 +394,48 @@
         "count": 3,
         "count_start": 5,
         "count_step": 5,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 1"
     },
     {
         "count": 4,
         "count_start": 20,
         "count_step": 10,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 2"
     },
     {
         "count": 8,
         "count_start": 75,
         "count_step": 25,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 3"
     },
     {
         "count": 5,
         "count_start": 300,
         "count_step": 50,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 4"
     },
     {
         "count": 5,
         "count_start": 600,
         "count_step": 100,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 5"
     },
     {
         "count": 6,
         "count_start": 1250,
         "count_step": 250,
-        "name": "Word: Score {count}+",
+        "name": "Word Score: {count}+",
         "region": "Stage 5"
     },
 
 
     {
-        "name": "Word: Use a ? Tile",
+        "name": "Use a Blank Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -451,7 +451,7 @@
         "character_tags": [ "Octacles" ]
     },
     {
-        "name": "Word: Use a Blue Tile",
+        "name": "Use a Blue Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -467,7 +467,7 @@
         "character_tags": [ "Rodman" ]
     },
     {
-        "name": "Word: Use a Chess Tile",
+        "name": "Use a Chess Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -486,62 +486,47 @@
         "character_tags": [ "Sam Gambit", "Octacles" ]
     },
     {
-        "name": "Word: Use a Card Tile",
-        "region": "Stage 1",
-        "access_rule": {
-            "rule": "And",
-            "children": [
-                {
-                    "rule": "HasAny",
-                    "args": {
-                        "item_names": [
-                            "Bones the Dog",
-                            "Octacles"
-                        ]
-                    }
-                }
-            ]
-        },
-        "character_tags": [ "Bones the Dog", "Octacles" ]
-    },
-    {
-        "name": "Word: Use a Currency Tile",
-        "region": "Stage 1",
-        "access_rule": {
-            "rule": "And",
-            "children": [
-                {
-                    "rule": "Has",
-                    "args": {
-                        "item_name": "Octacles"
-                    }
-                }
-            ]
-        },
-        "character_tags": [ "Octacles" ]
-    },
-    {
-        "name": "Word: Use a Fraction Tile",
-        "region": "Stage 1",
-        "access_rule": {
-            "rule": "And",
-            "children": [
-                {
-                    "rule": "Has",
-                    "args": {
-                        "item_name": "Octacles"
-                    }
-                }
-            ]
-        },
-        "character_tags": [ "Octacles" ]
-    },
-    {
-        "name": "Word: Use a Letter Tile",
+        "name": "Use a Colourless Tile",
         "region": "Stage 1"
     },
     {
-        "name": "Word: Use a Number Tile",
+        "name": "Use a Currency Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Octacles"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Octacles" ]
+    },
+    {
+        "name": "Use a Fraction Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Octacles"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Octacles" ]
+    },
+    {
+        "name": "Use a Letter Tile",
+        "region": "Stage 1"
+    },
+    {
+        "name": "Use a Number Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -560,7 +545,7 @@
         "character_tags": [ "Hayley Bayles", "Octacles" ]
     },
     {
-        "name": "Word: Use a Red Tile",
+        "name": "Use a Red Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -576,7 +561,7 @@
         "character_tags": [ "Rodman" ]
     },
     {
-        "name": "Word: Use a Shiny Tile",
+        "name": "Use a Shiny Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",
@@ -592,7 +577,26 @@
         "character_tags": [ "Nina Nix" ]
     },
     {
-        "name": "Word: Use a Void Tile",
+        "name": "Use a Suited Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "HasAny",
+                    "args": {
+                        "item_names": [
+                            "Bones the Dog",
+                            "Octacles"
+                        ]
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Bones the Dog", "Octacles" ]
+    },
+    {
+        "name": "Use a Void Tile",
         "region": "Stage 1",
         "access_rule": {
             "rule": "And",

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -280,15 +280,28 @@
         }
     },
     {
-        "count": 10,
-        "name": "Shop Stamp Item {count}",
+        "count": 30,
+        "name": "Shop Item {count}",
         "region": "Shop",
-        "tags": [ "Shopsanity" ]
-    },
-    {
-        "count": 10,
-        "name": "Shop Sticker Item {count}",
-        "region": "Shop",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "HasGroup",
+                    "args": {
+                        "item_name_group": "Stamp Slots",
+                        "count": 1
+                    }
+                },
+                {
+                    "rule": "HasGroup",
+                    "args": {
+                        "item_name_group": "Sticker Slots",
+                        "count": 1
+                    }
+                }
+            ]
+        },
         "tags": [ "Shopsanity" ]
     },
     {

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -280,6 +280,18 @@
         }
     },
     {
+        "count": 10,
+        "name": "Shop Stamp Item {count}",
+        "region": "Shop",
+        "tags": [ "Shopsanity" ]
+    },
+    {
+        "count": 10,
+        "name": "Shop Sticker Item {count}",
+        "region": "Shop",
+        "tags": [ "Shopsanity" ]
+    },
+    {
         "count": 5,
         "name": "Word Length {count}",
         "region": "Words"

--- a/worlds/cursed_words/data/locations.json
+++ b/worlds/cursed_words/data/locations.json
@@ -1,223 +1,238 @@
 [
     {
         "count": 3,
-        "name": "Rodman - 1-{count} Complete",
-        "region": "Rodman - Stage 1",
-        "tags": [ "Rodman" ]
+        "name": "Rodman: 1-{count} Complete",
+        "region": "Rodman: Stage 1",
+        "character_tags": [ "Rodman" ]
     },
     {
         "count": 3,
-        "name": "Rodman - 2-{count} Complete",
-        "region": "Rodman - Stage 2",
-        "tags": [ "Rodman" ]
+        "name": "Rodman: 2-{count} Complete",
+        "region": "Rodman: Stage 2",
+        "character_tags": [ "Rodman" ]
     },
     {
         "count": 3,
-        "name": "Rodman - 3-{count} Complete",
-        "region": "Rodman - Stage 3",
-        "tags": [ "Rodman" ]
+        "name": "Rodman: 3-{count} Complete",
+        "region": "Rodman: Stage 3",
+        "character_tags": [ "Rodman" ]
     },
     {
         "count": 3,
-        "name": "Rodman - 4-{count} Complete",
-        "region": "Rodman - Stage 4",
-        "tags": [ "Rodman" ]
+        "name": "Rodman: 4-{count} Complete",
+        "region": "Rodman: Stage 4",
+        "character_tags": [ "Rodman" ]
     },
     {
         "count": 3,
-        "name": "Rodman - 5-{count} Complete",
-        "region": "Rodman - Stage 5",
-        "tags": [ "Rodman" ]
+        "name": "Rodman: 5-{count} Complete",
+        "region": "Rodman: Stage 5",
+        "character_tags": [ "Rodman" ]
     },
     {
         "count": 3,
-        "name": "Nina Nix - 1-{count} Complete",
-        "region": "Nina Nix - Stage 1",
-        "tags": [ "Nina Nix" ]
+        "name": "Nina Nix: 1-{count} Complete",
+        "region": "Nina Nix: Stage 1",
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "count": 3,
-        "name": "Nina Nix - 2-{count} Complete",
-        "region": "Nina Nix - Stage 2",
-        "tags": [ "Nina Nix" ]
+        "name": "Nina Nix: 2-{count} Complete",
+        "region": "Nina Nix: Stage 2",
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "count": 3,
-        "name": "Nina Nix - 3-{count} Complete",
-        "region": "Nina Nix - Stage 3",
-        "tags": [ "Nina Nix" ]
+        "name": "Nina Nix: 3-{count} Complete",
+        "region": "Nina Nix: Stage 3",
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "count": 3,
-        "name": "Nina Nix - 4-{count} Complete",
-        "region": "Nina Nix - Stage 4",
-        "tags": [ "Nina Nix" ]
+        "name": "Nina Nix: 4-{count} Complete",
+        "region": "Nina Nix: Stage 4",
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "count": 3,
-        "name": "Nina Nix - 5-{count} Complete",
-        "region": "Nina Nix - Stage 5",
-        "tags": [ "Nina Nix" ]
+        "name": "Nina Nix: 5-{count} Complete",
+        "region": "Nina Nix: Stage 5",
+        "character_tags": [ "Nina Nix" ]
     },
     {
         "count": 3,
-        "name": "Hayley Bayles - 1-{count} Complete",
-        "region": "Hayley Bayles - Stage 1",
-        "tags": [ "Hayley Bayles" ]
+        "name": "Hayley Bayles: 1-{count} Complete",
+        "region": "Hayley Bayles: Stage 1",
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "count": 3,
-        "name": "Hayley Bayles - 2-{count} Complete",
-        "region": "Hayley Bayles - Stage 2",
-        "tags": [ "Hayley Bayles" ]
+        "name": "Hayley Bayles: 2-{count} Complete",
+        "region": "Hayley Bayles: Stage 2",
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "count": 3,
-        "name": "Hayley Bayles - 3-{count} Complete",
-        "region": "Hayley Bayles - Stage 3",
-        "tags": [ "Hayley Bayles" ]
+        "name": "Hayley Bayles: 3-{count} Complete",
+        "region": "Hayley Bayles: Stage 3",
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "count": 3,
-        "name": "Hayley Bayles - 4-{count} Complete",
-        "region": "Hayley Bayles - Stage 4",
-        "tags": [ "Hayley Bayles" ]
+        "name": "Hayley Bayles: 4-{count} Complete",
+        "region": "Hayley Bayles: Stage 4",
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "count": 3,
-        "name": "Hayley Bayles - 5-{count} Complete",
-        "region": "Hayley Bayles - Stage 5",
-        "tags": [ "Hayley Bayles" ]
+        "name": "Hayley Bayles: 5-{count} Complete",
+        "region": "Hayley Bayles: Stage 5",
+        "character_tags": [ "Hayley Bayles" ]
     },
     {
         "count": 3,
-        "name": "Bones the Dog - 1-{count} Complete",
-        "region": "Bones the Dog - Stage 1",
-        "tags": [ "Bones the Dog" ]
+        "name": "Bones the Dog: 1-{count} Complete",
+        "region": "Bones the Dog: Stage 1",
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "count": 3,
-        "name": "Bones the Dog - 2-{count} Complete",
-        "region": "Bones the Dog - Stage 2",
-        "tags": [ "Bones the Dog" ]
+        "name": "Bones the Dog: 2-{count} Complete",
+        "region": "Bones the Dog: Stage 2",
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "count": 3,
-        "name": "Bones the Dog - 3-{count} Complete",
-        "region": "Bones the Dog - Stage 3",
-        "tags": [ "Bones the Dog" ]
+        "name": "Bones the Dog: 3-{count} Complete",
+        "region": "Bones the Dog: Stage 3",
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "count": 3,
-        "name": "Bones the Dog - 4-{count} Complete",
-        "region": "Bones the Dog - Stage 4",
-        "tags": [ "Bones the Dog" ]
+        "name": "Bones the Dog: 4-{count} Complete",
+        "region": "Bones the Dog: Stage 4",
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "count": 3,
-        "name": "Bones the Dog - 5-{count} Complete",
-        "region": "Bones the Dog - Stage 5",
-        "tags": [ "Bones the Dog" ]
+        "name": "Bones the Dog: 5-{count} Complete",
+        "region": "Bones the Dog: Stage 5",
+        "character_tags": [ "Bones the Dog" ]
     },
     {
         "count": 3,
-        "name": "Sam Gambit - 1-{count} Complete",
-        "region": "Sam Gambit - Stage 1",
-        "tags": [ "Sam Gambit" ]
+        "name": "Sam Gambit: 1-{count} Complete",
+        "region": "Sam Gambit: Stage 1",
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "count": 3,
-        "name": "Sam Gambit - 2-{count} Complete",
-        "region": "Sam Gambit - Stage 2",
-        "tags": [ "Sam Gambit" ]
+        "name": "Sam Gambit: 2-{count} Complete",
+        "region": "Sam Gambit: Stage 2",
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "count": 3,
-        "name": "Sam Gambit - 3-{count} Complete",
-        "region": "Sam Gambit - Stage 3",
-        "tags": [ "Sam Gambit" ]
+        "name": "Sam Gambit: 3-{count} Complete",
+        "region": "Sam Gambit: Stage 3",
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "count": 3,
-        "name": "Sam Gambit - 4-{count} Complete",
-        "region": "Sam Gambit - Stage 4",
-        "tags": [ "Sam Gambit" ]
+        "name": "Sam Gambit: 4-{count} Complete",
+        "region": "Sam Gambit: Stage 4",
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "count": 3,
-        "name": "Sam Gambit - 5-{count} Complete",
-        "region": "Sam Gambit - Stage 5",
-        "tags": [ "Sam Gambit" ]
+        "name": "Sam Gambit: 5-{count} Complete",
+        "region": "Sam Gambit: Stage 5",
+        "character_tags": [ "Sam Gambit" ]
     },
     {
         "count": 3,
-        "name": "Octacles - 1-{count} Complete",
-        "region": "Octacles - Stage 1",
-        "tags": [ "Octacles" ]
+        "name": "Octacles: 1-{count} Complete",
+        "region": "Octacles: Stage 1",
+        "character_tags": [ "Octacles" ]
     },
     {
         "count": 3,
-        "name": "Octacles - 2-{count} Complete",
-        "region": "Octacles - Stage 2",
-        "tags": [ "Octacles" ]
+        "name": "Octacles: 2-{count} Complete",
+        "region": "Octacles: Stage 2",
+        "character_tags": [ "Octacles" ]
     },
     {
         "count": 3,
-        "name": "Octacles - 3-{count} Complete",
-        "region": "Octacles - Stage 3",
-        "tags": [ "Octacles" ]
+        "name": "Octacles: 3-{count} Complete",
+        "region": "Octacles: Stage 3",
+        "character_tags": [ "Octacles" ]
     },
     {
         "count": 3,
-        "name": "Octacles - 4-{count} Complete",
-        "region": "Octacles - Stage 4",
-        "tags": [ "Octacles" ]
+        "name": "Octacles: 4-{count} Complete",
+        "region": "Octacles: Stage 4",
+        "character_tags": [ "Octacles" ]
     },
     {
         "count": 3,
-        "name": "Octacles - 5-{count} Complete",
-        "region": "Octacles - Stage 5",
-        "tags": [ "Octacles" ]
+        "name": "Octacles: 5-{count} Complete",
+        "region": "Octacles: Stage 5",
+        "character_tags": [ "Octacles" ]
+    },
+
+
+    {
+        "name": "Run: Destroy a Consumable Tile",
+        "region": "Stage 1"
     },
     {
-        "name": "Skip a Grid",
-        "region": "Encounters"
+        "count": 3,
+        "count_start": 5,
+        "count_step": 5,
+        "name": "Run: Earn ${count} Total",
+        "region": "Stage 1"
     },
     {
-        "name": "Place a Consumable Tile",
-        "region": "Encounters"
+        "count": 4,
+        "count_start": 20,
+        "count_step": 10,
+        "name": "Run: Earn ${count} Total",
+        "region": "Stage 2"
     },
     {
-        "name": "Earn $10",
-        "region": "Money"
+        "count": 8,
+        "count_start": 75,
+        "count_step": 25,
+        "name": "Run: Earn ${count} Total",
+        "region": "Stage 3"
     },
     {
-        "name": "Earn $25",
-        "region": "Money"
+        "count": 5,
+        "count_start": 300,
+        "count_step": 50,
+        "name": "Run: Earn ${count} Total",
+        "region": "Stage 4"
     },
     {
-        "name": "Earn $50",
-        "region": "Money"
+        "count": 5,
+        "count_start": 600,
+        "count_step": 10,
+        "name": "Run: Earn ${count} Total",
+        "region": "Stage 5"
     },
     {
-        "name": "Earn $75",
-        "region": "Money Medium"
+        "name": "Run: Place a Consumable Tile",
+        "region": "Stage 1"
     },
     {
-        "name": "Earn $100",
-        "region": "Money Medium"
+        "name": "Run: Skip a Grid",
+        "region": "Stage 1"
     },
+
+
     {
-        "name": "Earn $250",
-        "region": "Money High"
-    },
-    {
-        "name": "Earn $500",
-        "region": "Money High"
-    },
-    {
-        "name": "Buy a Sticker",
-        "region": "Shop",
+        "name": "Shop: Buy a Sticker",
+        "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
             "options": [
@@ -235,8 +250,8 @@
         }
     },
     {
-        "name": "Buy a Stamp",
-        "region": "Shop",
+        "name": "Shop: Buy a Stamp",
+        "region": "Stage 1",
         "access_rule": {
             "rule": "HasGroup",
             "options": [
@@ -254,67 +269,13 @@
         }
     },
     {
-        "name": "Buy a Consumable Tile",
-        "region": "Shop"
-    },
-    {
-        "name": "Destroy a Consumable Tile",
-        "region": "Shop"
-    },
-    {
-        "name": "Freeze a Stamp",
-        "region": "Shop"
-    },
-    {
-        "name": "Freeze a Sticker",
-        "region": "Shop"
-    },
-    {
-        "name": "Restock the Shop",
-        "region": "Shop"
-    },
-    {
-        "name": "Sell a Sticker",
-        "region": "Shop",
-        "access_rule": {
-            "rule": "HasGroup",
-            "options": [
-                {
-                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                    "value": 1,
-                    "operator": "eq"
-                }
-            ],
-            "args" : {
-                "item_name_group": "Sticker Slots",
-                "count": 1
-            },
-            "filtered_resolution": true
-        }
-    },
-    {
-        "name": "Sell a Stamp",
-        "region": "Shop",
-        "access_rule": {
-            "rule": "HasGroup",
-            "options": [
-                {
-                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                    "value": 1,
-                    "operator": "eq"
-                }
-            ],
-            "args" : {
-                "item_name_group": "Stamp Slots",
-                "count": 1
-            },
-            "filtered_resolution": true
-        }
+        "name": "Shop: Buy a Consumable Tile",
+        "region": "Stage 1"
     },
     {
         "count": 30,
-        "name": "Shop Item {count}",
-        "region": "Shop",
+        "name": "Shop: Buy Shopsanity Item {count}",
+        "region": "Stage 1",
         "access_rule": {
             "rule": "And",
             "children": [
@@ -350,83 +311,300 @@
                 }
             ]
         },
-        "tags": [ "Shopsanity" ]
+        "option_tags": [ "Shopsanity" ]
+    },
+    {
+        "name": "Shop: Freeze a Stamp",
+        "region": "Stage 1"
+    },
+    {
+        "name": "Shop: Freeze a Sticker",
+        "region": "Stage 1"
+    },
+    {
+        "name": "Shop: Restock the Shop",
+        "region": "Stage 1"
+    },
+    {
+        "name": "Shop: Sell a Sticker",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
+            "args" : {
+                "item_name_group": "Sticker Slots",
+                "count": 1
+            },
+            "filtered_resolution": true
+        }
+    },
+    {
+        "name": "Shop: Sell a Stamp",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "HasGroup",
+            "options": [
+                {
+                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
+                    "value": 1,
+                    "operator": "eq"
+                }
+            ],
+            "args" : {
+                "item_name_group": "Stamp Slots",
+                "count": 1
+            },
+            "filtered_resolution": true
+        }
+    },
+
+    
+    {
+        "count": 3,
+        "name": "Word: Length {count} Tiles",
+        "region": "Stage 1"
+    },
+    {
+        "count": 3,
+        "count_start": 4,
+        "name": "Word: Length {count} Tiles",
+        "region": "Stage 2"
+    },
+    {
+        "count": 3,
+        "count_start": 7,
+        "name": "Word: Length {count} Tiles",
+        "region": "Stage 3"
+    },
+    {
+        "count": 3,
+        "count_start": 10,
+        "name": "Word: Length {count} Tiles",
+        "region": "Stage 4"
+    },
+
+
+    {
+        "count": 3,
+        "count_start": 5,
+        "count_step": 5,
+        "name": "Word: Score {count}+",
+        "region": "Stage 1"
+    },
+    {
+        "count": 4,
+        "count_start": 20,
+        "count_step": 10,
+        "name": "Word: Score {count}+",
+        "region": "Stage 2"
+    },
+    {
+        "count": 8,
+        "count_start": 75,
+        "count_step": 25,
+        "name": "Word: Score {count}+",
+        "region": "Stage 3"
     },
     {
         "count": 5,
-        "name": "Word Length {count}",
-        "region": "Words"
+        "count_start": 300,
+        "count_step": 50,
+        "name": "Word: Score {count}+",
+        "region": "Stage 4"
     },
     {
-        "name": "Word Length 6",
-        "region": "Words Medium"
+        "count": 5,
+        "count_start": 600,
+        "count_step": 100,
+        "name": "Word: Score {count}+",
+        "region": "Stage 5"
     },
     {
-        "name": "Word Length 7",
-        "region": "Words Medium"
+        "count": 6,
+        "count_start": 1250,
+        "count_step": 250,
+        "name": "Word: Score {count}+",
+        "region": "Stage 5"
+    },
+
+
+    {
+        "name": "Word: Use a ? Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Octacles"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Octacles" ]
     },
     {
-        "name": "Word Length 8",
-        "region": "Words Medium"
+        "name": "Word: Use a Blue Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Rodman"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Rodman" ]
     },
     {
-        "name": "Word Length 9",
-        "region": "Words Medium"
+        "name": "Word: Use a Chess Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "HasAny",
+                    "args": {
+                        "item_names": [
+                            "Sam Gambit",
+                            "Octacles"
+                        ]
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Sam Gambit", "Octacles" ]
     },
     {
-        "name": "Word Length 10",
-        "region": "Words High"
+        "name": "Word: Use a Card Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "HasAny",
+                    "args": {
+                        "item_names": [
+                            "Bones the Dog",
+                            "Octacles"
+                        ]
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Bones the Dog", "Octacles" ]
     },
     {
-        "name": "Word Length 11",
-        "region": "Words High"
+        "name": "Word: Use a Currency Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Octacles"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Octacles" ]
     },
     {
-        "name": "Word Length 12",
-        "region": "Words High"
+        "name": "Word: Use a Fraction Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Octacles"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Octacles" ]
     },
     {
-        "name": "Word Score > 5",
-        "region": "Words"
+        "name": "Word: Use a Letter Tile",
+        "region": "Stage 1"
     },
     {
-        "name": "Word Score > 10",
-        "region": "Words"
+        "name": "Word: Use a Number Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "HasAny",
+                    "args": {
+                        "item_names": [
+                            "Hayley Bayles",
+                            "Octacles"
+                        ]
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Hayley Bayles", "Octacles" ]
     },
     {
-        "name": "Word Score > 25",
-        "region": "Words"
+        "name": "Word: Use a Red Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Rodman"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Rodman" ]
     },
     {
-        "name": "Word Score > 50",
-        "region": "Words Medium"
+        "name": "Word: Use a Shiny Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Nina Nix"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Nina Nix" ]
     },
     {
-        "name": "Word Score > 75",
-        "region": "Words Medium"
-    },
-    {
-        "name": "Word Score > 100",
-        "region": "Words Medium"
-    },
-    {
-        "name": "Word Score > 250",
-        "region": "Words Medium"
-    },
-    {
-        "name": "Word Score > 500",
-        "region": "Words High"
-    },
-    {
-        "name": "Word Score > 750",
-        "region": "Words High"
-    },
-    {
-        "name": "Word Score > 1000",
-        "region": "Words High"
-    },
-    {
-        "name": "Word Score > 1500",
-        "region": "Words High"
+        "name": "Word: Use a Void Tile",
+        "region": "Stage 1",
+        "access_rule": {
+            "rule": "And",
+            "children": [
+                {
+                    "rule": "Has",
+                    "args": {
+                        "item_name": "Nina Nix"
+                    }
+                }
+            ]
+        },
+        "character_tags": [ "Nina Nix" ]
     }
 ]

--- a/worlds/cursed_words/data/regions.json
+++ b/worlds/cursed_words/data/regions.json
@@ -4,775 +4,198 @@
         "exits": [
             {
                 "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Rodman"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Rodman - Stage 1",
-                "destination": "Rodman - Stage 1",
-                "tags": [ "Rodman" ]
-            },
-            {
-                "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Nina Nix"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Nina Nix - Stage 1",
-                "destination": "Nina Nix - Stage 1",
-                "tags": [ "Nina Nix" ]
-            },
-            {
-                "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Hayley Bayles"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Hayley Bayles - Stage 1",
-                "destination": "Hayley Bayles - Stage 1",
-                "tags": [ "Hayley Bayles" ]
-            },
-            {
-                "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Bones the Dog"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Bones the Dog - Stage 1",
-                "destination": "Bones the Dog - Stage 1",
-                "tags": [ "Bones the Dog" ]
-            },
-            {
-                "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Sam Gambit"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Sam Gambit - Stage 1",
-                "destination": "Sam Gambit - Stage 1",
-                "tags": [ "Sam Gambit" ]
-            },
-            {
-                "access_rule": {
-                    "rule": "HasAll",
-                    "options": [],
-                    "args": {
-                        "item_names": [
-                            "Octacles"
-                        ]
-                    }
-
-                },
-                "name": "Menu to Octacles - Stage 1",
-                "destination": "Octacles - Stage 1",
-                "tags": [ "Octacles" ]
-            },
-            {
-                "access_rule": {
                     "rule": "HasGroup",
-                    "options": [],
                     "args": {
                         "item_name_group": "Characters",
                         "count": 1
                     }
-
                 },
-                "name": "Menu to Encounters",
-                "destination": "Encounters"
+                "name": "Menu to Stages",
+                "destination": "Stage 1"
+            }
+        ]
+    },
+    
+    {
+        "name": "Stage 1",
+        "exits": [
+            {
+                "name": "to Stage 2",
+                "destination": "Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "And",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "children": [
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamp Slots",
+                                        "count": 1
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Sticker Slots",
+                                        "count": 1
+                                    }
+                                }
+                            ],
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "And",
+                            "children": [
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamps",
+                                        "count": 10
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stickers",
+                                        "count": 10
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
             },
             {
+                "name": "to Rodman: Stage 1",
+                "destination": "Rodman: Stage 1",
                 "access_rule": {
-                    "rule": "HasGroup",
-                    "options": [],
-                    "args": {
-                        "item_name_group": "Characters",
-                        "count": 1
-                    }
-
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Rodman"
+                            }
+                        }
+                    ]
                 },
-                "name": "Menu to Money",
-                "destination": "Money"
+                "character_tags": [ "Rodman" ]
             },
             {
+                "name": "to Nina Nix: Stage 1",
+                "destination": "Nina Nix: Stage 1",
                 "access_rule": {
-                    "rule": "HasGroup",
-                    "options": [],
-                    "args": {
-                        "item_name_group": "Characters",
-                        "count": 1
-                    }
-
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Nina Nix"
+                            }
+                        }
+                    ]
                 },
-                "name": "Menu to Shop",
-                "destination": "Shop"
+                "character_tags": [ "Nina Nix" ]
             },
             {
+                "name": "to Hayley Bayles: Stage 1",
+                "destination": "Hayley Bayles: Stage 1",
                 "access_rule": {
-                    "rule": "HasGroup",
-                    "options": [],
-                    "args": {
-                        "item_name_group": "Characters",
-                        "count": 1
-                    }
-
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Hayley Bayles"
+                            }
+                        }
+                    ]
                 },
-                "name": "Menu to Words",
-                "destination": "Words"
+                "character_tags": [ "Hayley Bayles" ]
+            },
+            {
+                "name": "to Sam Gambit: Stage 1",
+                "destination": "Sam Gambit: Stage 1",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Sam Gambit"
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Sam Gambit" ]
+            },
+            {
+                "name": "to Bones the Dog: Stage 1",
+                "destination": "Bones the Dog: Stage 1",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Bones the Dog"
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Bones the Dog" ]
+            },
+            {
+                "name": "to Octacles: Stage 1",
+                "destination": "Octacles: Stage 1",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Octacles"
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Octacles" ]
             }
         ]
     },
     {
-        "name": "Encounters"
-    },
-    {
-        "name": "Money",
+        "name": "Stage 2",
         "exits": [
             {
-                "name": "Money to Medium",
-                "destination": "Money Medium",
+                "name": "to Stage 3",
+                "destination": "Stage 3",
                 "access_rule": {
                     "rule": "And",
                     "children": [
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Stamp Bundles",
-                                "count": 2
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Sticker Bundles",
-                                "count": 2
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Tiles",
-                                "count": 2
-                            }
-                        }
-                    ]
-                }
-            }
-        ]
-    },
-    {
-        "name": "Money Medium",
-        "exits": [
-            {
-                "name": "Money to High",
-                "destination": "Money High",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Stamp Bundles",
-                                "count": 4
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Sticker Bundles",
-                                "count": 4
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Tiles",
-                                "count": 4
-                            }
-                        }
-                    ]
-                }
-            }
-        ]
-    },
-    {
-        "name": "Money High"
-    },
-    {
-        "name": "Shop"
-    },
-    {
-        "name": "Words",
-        "exits": [
-            {
-                "name": "Words to Medium",
-                "destination": "Words Medium",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Stamp Bundles",
-                                "count": 2
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Sticker Bundles",
-                                "count": 2
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Tiles",
-                                "count": 2
-                            }
-                        }
-                    ]
-                }
-            }
-        ]
-    },
-    {
-        "name": "Words Medium",
-        "exits": [
-            {
-                "name": "Words to High",
-                "destination": "Words High",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Stamp Bundles",
-                                "count": 4
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Sticker Bundles",
-                                "count": 4
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Sticker Slots",
-                                "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args" : {
-                                "item_name_group": "Stamp Slots",
-                                "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args" : {
-                                "item_name_group": "Tiles",
-                                "count": 4
-                            }
-                        }
-                    ]
-                }
-            }
-        ]
-    },
-    {
-        "name": "Words High"
-    },
-    {
-        "name": "Rodman - Stage 1",
-        "exits": [
-            {
-                "name": "Rodman to Stage 2",
-                "destination": "Rodman - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Blue Tiles",
-                                    "Red Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Rodman" ]
-    },
-    {
-        "name": "Rodman - Stage 2",
-        "exits": [
-            {
-                "name": "Rodman to Stage 3",
-                "destination": "Rodman - Stage 3",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Blue Stickers",
-                                    "Red Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Blue Tiles",
-                                    "Red Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Rodman" ]
-    },
-    {
-        "name": "Rodman - Stage 3",
-        "exits": [
-            {
-                "name": "Rodman to Stage 4",
-                "destination": "Rodman - Stage 4",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Blue Stickers",
-                                    "Red Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Blue Stickers",
-                                    "Red Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Rodman" ]
-    },
-    {
-        "name": "Rodman - Stage 4",
-        "exits": [
-            {
-                "name": "Rodman to Stage 5",
-                "destination": "Rodman - Stage 5",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Blue Stamps",
-                                    "Red Stamps"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Rodman" ]
-    },
-    {
-        "name": "Rodman - Stage 5",
-        "tags": [ "Rodman" ]
-    },
-    {
-        "name": "Nina Nix - Stage 1",
-        "exits": [
-            {
-                "name": "Nina Nix to Stage 2",
-                "destination": "Nina Nix - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Nina Nix" ]
-    },
-    {
-        "name": "Nina Nix - Stage 2",
-        "exits": [
-            {
-                "name": "Nina Nix to Stage 3",
-                "destination": "Nina Nix - Stage 3",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Shiny Stickers",
-                                    "Void Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Shiny Tiles",
-                                    "Void Tiles"
-                                ]
-                            }
-                        },
                         {
                             "rule": "HasGroup",
                             "options": [
@@ -804,7 +227,7 @@
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
+                            "rule": "And",
                             "options": [
                                 {
                                     "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
@@ -812,59 +235,294 @@
                                     "operator": "eq"
                                 }
                             ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
+                            "children": [
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamp Slots",
+                                        "count": 2
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Sticker Slots",
+                                        "count": 2
+                                    }
+                                }
+                            ],
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
-                            "options": [
+                            "rule": "And",
+                            "children": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamps",
+                                        "count": 12
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stickers",
+                                        "count": 12
+                                    }
                                 }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
+                            ]
                         }
                     ]
                 }
-            }
-        ],
-        "tags": [ "Nina Nix" ]
-    },
-    {
-        "name": "Nina Nix - Stage 3",
-        "exits": [
+            },
             {
-                "name": "Nina Nix to Stage 4",
-                "destination": "Nina Nix - Stage 4",
+                "name": "to Rodman: Stage 2",
+                "destination": "Rodman: Stage 2",
                 "access_rule": {
                     "rule": "And",
                     "children": [
                         {
-                            "rule": "HasAll",
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Shiny Stickers",
-                                    "Void Stickers"
-                                ]
+                                "item_name": "Rodman"
                             }
                         },
                         {
-                            "rule": "HasAny",
+                            "rule": "Or",
+                            "children": [
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scattering",
+                                                "count": 2
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scoring",
+                                                "count": 2
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scattering",
+                                                "count": 2
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scoring",
+                                                "count": 2
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "character_tags": [ "Rodman" ]
+            },
+            {
+                "name": "to Nina Nix: Stage 2",
+                "destination": "Nina Nix: Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Shiny Stamps",
-                                    "Void Stamps"
-                                ]
+                                "item_name": "Nina Nix"
                             }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scattering",
+                                "count": 1
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scoring",
+                                "count": 1
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scattering",
+                                "count": 1
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scoring",
+                                "count": 1
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Nina Nix" ]
+            },
+            {
+                "name": "to Hayley Bayles: Stage 2",
+                "destination": "Hayley Bayles: Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Hayley Bayles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scattering",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scoring",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Hayley Bayles" ]
+            },
+            {
+                "name": "to Sam Gambit: Stage 2",
+                "destination": "Sam Gambit: Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Sam Gambit"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scattering",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scoring",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Sam Gambit" ]
+            },
+            {
+                "name": "to Bones the Dog: Stage 2",
+                "destination": "Bones the Dog: Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Bones the Dog"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scattering",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scoring",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Bones the Dog" ]
+            },
+            {
+                "name": "to Octacles: Stage 2",
+                "destination": "Octacles: Stage 2",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Octacles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scattering",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scoring",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Octacles" ]
+            }
+        ]
+    },
+    {
+        "name": "Stage 3",
+        "exits": [
+            {
+                "name": "to Stage 4",
+                "destination": "Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -882,7 +540,7 @@
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
+                            "rule": "And",
                             "options": [
                                 {
                                     "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
@@ -890,1321 +548,280 @@
                                     "operator": "eq"
                                 }
                             ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
+                            "children": [
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamp Slots",
+                                        "count": 3
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Sticker Slots",
+                                        "count": 3
+                                    }
+                                }
+                            ],
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
-                            "options": [
+                            "rule": "And",
+                            "children": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamps",
+                                        "count": 14
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stickers",
+                                        "count": 14
+                                    }
                                 }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
+                            ]
                         }
                     ]
                 }
-            }
-        ],
-        "tags": [ "Nina Nix" ]
-    },
-    {
-        "name": "Nina Nix - Stage 4",
-        "exits": [
+            },
             {
-                "name": "Nina Nix to Stage 5",
-                "destination": "Nina Nix - Stage 5",
+                "name": "to Rodman: Stage 3",
+                "destination": "Rodman: Stage 3",
                 "access_rule": {
                     "rule": "And",
                     "children": [
                         {
-                            "rule": "HasAll",
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Shiny Stamps",
-                                    "Void Stamps"
-                                ]
+                                "item_name": "Rodman"
+                            }
+                        },
+                        {
+                            "rule": "Or",
+                            "children": [
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scattering",
+                                                "count": 4
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scoring",
+                                                "count": 4
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scattering",
+                                                "count": 4
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scoring",
+                                                "count": 4
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "character_tags": [ "Rodman" ]
+            },
+            {
+                "name": "to Nina Nix: Stage 3",
+                "destination": "Nina Nix: Stage 3",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Nina Nix"
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Grid Sizes",
+                                "item_name_group": "Shiny Scattering",
                                 "count": 2
-                            },
-                            "filtered_resolution": true
+                            }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 8
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Nina Nix" ]
-    },
-    {
-        "name": "Nina Nix - Stage 5",
-        "tags": [ "Nina Nix" ]
-    },
-    {
-        "name": "Hayley Bayles - Stage 1",
-        "exits": [
-            {
-                "name": "Hayley Bayles to Stage 2",
-                "destination": "Hayley Bayles - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Shiny Scoring",
                                 "count": 2
-                            },
-                            "filtered_resolution": true
+                            }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
+                                "item_name_group": "Void Scattering",
+                                "count": 2
+                            }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
+                                "item_name_group": "Void Scoring",
+                                "count": 2
+                            }
                         }
                     ]
-                }
-            }
-        ],
-        "tags": [ "Hayley Bayles" ]
-    },
-    {
-        "name": "Hayley Bayles - Stage 2",
-        "exits": [
+                },
+                "character_tags": [ "Nina Nix" ]
+            },
             {
-                "name": "Hayley Bayles to Stage 3",
-                "destination": "Hayley Bayles - Stage 3",
+                "name": "to Hayley Bayles: Stage 3",
+                "destination": "Hayley Bayles: Stage 3",
                 "access_rule": {
                     "rule": "And",
                     "children": [
                         {
-                            "rule": "HasAll",
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Number Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Fraction Tiles",
-                                    "Number Tiles"
-                                ]
+                                "item_name": "Hayley Bayles"
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Number Scattering",
                                 "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Hayley Bayles" ]
-    },
-    {
-        "name": "Hayley Bayles - Stage 3",
-        "exits": [
-            {
-                "name": "Hayley Bayles to Stage 4",
-                "destination": "Hayley Bayles - Stage 4",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Number Stamps"
-                                ]
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 6
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Hayley Bayles" ]
-    },
-    {
-        "name": "Hayley Bayles - Stage 4",
-        "exits": [
-            {
-                "name": "Hayley Bayles to Stage 5",
-                "destination": "Hayley Bayles - Stage 5",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Fraction Tiles",
-                                    "Number Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 8
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Hayley Bayles" ]
-    },
-    {
-        "name": "Hayley Bayles - Stage 5",
-        "exits": [],
-        "tags": [ "Hayley Bayles" ]
-    },
-    {
-        "name": "Bones the Dog - Stage 1",
-        "exits": [
-            {
-                "name": "Bones the Dog to Stage 2",
-                "destination": "Bones the Dog - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Bones the Dog" ]
-    },
-    {
-        "name": "Bones the Dog - Stage 2",
-        "exits": [
-            {
-                "name": "Bones the Dog to Stage 3",
-                "destination": "Bones the Dog - Stage 3",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Card Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Card Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Number Scoring",
                                 "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
+                            }
                         }
                     ]
-                }
-            }
-        ],
-        "tags": [ "Bones the Dog" ]
-    },
-    {
-        "name": "Bones the Dog - Stage 3",
-        "exits": [
+                },
+                "character_tags": [ "Hayley Bayles" ]
+            },
             {
-                "name": "Bones the Dog to Stage 4",
-                "destination": "Bones the Dog - Stage 4",
+                "name": "to Sam Gambit: Stage 3",
+                "destination": "Sam Gambit: Stage 3",
                 "access_rule": {
                     "rule": "And",
                     "children": [
                         {
-                            "rule": "HasAll",
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Card Stamps"
-                                ]
+                                "item_name": "Sam Gambit"
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 6
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Bones the Dog" ]
-    },
-    {
-        "name": "Bones the Dog - Stage 4",
-        "exits": [
-            {
-                "name": "Bones the Dog to Stage 5",
-                "destination": "Bones the Dog - Stage 5",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 8
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Bones the Dog" ]
-    },
-    {
-        "name": "Bones the Dog - Stage 5",
-        "exits": [],
-        "tags": [ "Bones the Dog" ]
-    },
-    {
-        "name": "Sam Gambit - Stage 1",
-        "exits": [
-            {
-                "name": "Sam Gambit to Stage 2",
-                "destination": "Sam Gambit - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Sam Gambit" ]
-    },
-    {
-        "name": "Sam Gambit - Stage 2",
-        "exits": [
-            {
-                "name": "Sam Gambit to Stage 3",
-                "destination": "Sam Gambit - Stage 3",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Chess Scattering",
                                 "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Sam Gambit" ]
-    },
-    {
-        "name": "Sam Gambit - Stage 3",
-        "exits": [
-            {
-                "name": "Sam Gambit to Stage 4",
-                "destination": "Sam Gambit - Stage 4",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stamps"
-                                ]
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 6
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Sam Gambit" ]
-    },
-    {
-        "name": "Sam Gambit - Stage 4",
-        "exits": [
-            {
-                "name": "Sam Gambit to Stage 5",
-                "destination": "Sam Gambit - Stage 5",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 8
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Sam Gambit" ]
-    },
-    {
-        "name": "Sam Gambit - Stage 5",
-        "exits": [],
-        "tags": [ "Sam Gambit" ]
-    },
-    {
-        "name": "Octacles - Stage 1",
-        "exits": [
-            {
-                "name": "Octacles to Stage 2",
-                "destination": "Octacles - Stage 2",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        }
-                    ]
-                }
-            }
-        ],
-        "tags": [ "Octacles" ]
-    },
-    {
-        "name": "Octacles - Stage 2",
-        "exits": [
-            {
-                "name": "Octacles to Stage 3",
-                "destination": "Octacles - Stage 3",
-                "access_rule": {
-                    "rule": "And",
-                    "children": [
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Cursed Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stickers",
-                                    "Number Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Chess Tiles",
-                                    "Currency Tiles",
-                                    "Fraction Tiles",
-                                    "Number Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 1
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Chess Scoring",
                                 "count": 4
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
+                            }
                         }
                     ]
-                }
-            }
-        ],
-        "tags": [ "Octacles" ]
-    },
-    {
-        "name": "Octacles - Stage 3",
-        "exits": [
+                },
+                "character_tags": [ "Sam Gambit" ]
+            },
             {
-                "name": "Octacles to Stage 4",
-                "destination": "Octacles - Stage 4",
+                "name": "to Bones the Dog: Stage 3",
+                "destination": "Bones the Dog: Stage 3",
                 "access_rule": {
                     "rule": "And",
                     "children": [
                         {
-                            "rule": "HasAll",
+                            "rule": "Has",
                             "args": {
-                                "item_names": [
-                                    "Cursed Stamps"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAny",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stamps",
-                                    "Number Stamps"
-                                ]
+                                "item_name": "Bones the Dog"
                             }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Tile Positions",
+                                "item_name_group": "Card Scattering",
+                                "count": 4
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scoring",
+                                "count": 4
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Bones the Dog" ]
+            },
+            {
+                "name": "to Octacles: Stage 3",
+                "destination": "Octacles: Stage 3",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Octacles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scattering",
                                 "count": 6
-                            },
-                            "filtered_resolution": true
+                            }
                         },
                         {
                             "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
                             "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 3
-                            },
-                            "filtered_resolution": true
+                                "item_name_group": "Cursed Scoring",
+                                "count": 4
+                            }
                         }
                     ]
-                }
+                },
+                "character_tags": [ "Octacles" ]
             }
-        ],
-        "tags": [ "Octacles" ]
+        ]
     },
     {
-        "name": "Octacles - Stage 4",
+        "name": "Stage 4",
         "exits": [
             {
-                "name": "Octacles to Stage 5",
-                "destination": "Octacles - Stage 5",
+                "name": "to Stage 5",
+                "destination": "Stage 5",
                 "access_rule": {
                     "rule": "And",
                     "children": [
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stickers",
-                                    "Number Stickers"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Stamps",
-                                    "Number Stamps"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasAll",
-                            "args": {
-                                "item_names": [
-                                    "Chess Tiles",
-                                    "Currency Tiles",
-                                    "Fraction Tiles",
-                                    "Number Tiles"
-                                ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "options": [
-                                {
-                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
-                                    "value": 1,
-                                    "operator": "eq"
-                                }
-                            ],
-                            "args": {
-                                "item_name_group": "Grid Sizes",
-                                "count": 2
-                            },
-                            "filtered_resolution": true
-                        },
                         {
                             "rule": "HasGroup",
                             "options": [
@@ -2216,12 +833,12 @@
                             ],
                             "args": {
                                 "item_name_group": "Tile Positions",
-                                "count": 8
+                                "count": 10
                             },
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
+                            "rule": "And",
                             "options": [
                                 {
                                     "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
@@ -2229,36 +846,539 @@
                                     "operator": "eq"
                                 }
                             ],
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
-                            },
+                            "children": [
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamp Slots",
+                                        "count": 5
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Sticker Slots",
+                                        "count": 5
+                                    }
+                                }
+                            ],
                             "filtered_resolution": true
                         },
                         {
-                            "rule": "HasGroup",
-                            "options": [
+                            "rule": "And",
+                            "children": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
-                                    "value": 1,
-                                    "operator": "eq"
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stamps",
+                                        "count": 16
+                                    }
+                                },
+                                {
+                                    "rule": "HasGroup",
+                                    "args": {
+                                        "item_name_group": "Stickers",
+                                        "count": 16
+                                    }
                                 }
-                            ],
-                            "args": {
-                                "item_name_group": "Stamp Slots",
-                                "count": 5
-                            },
-                            "filtered_resolution": true
+                            ]
                         }
                     ]
                 }
+            },
+            {
+                "name": "to Rodman: Stage 4",
+                "destination": "Rodman: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Rodman"
+                            }
+                        },
+                        {
+                            "rule": "Or",
+                            "children": [
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scattering",
+                                                "count": 6
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scoring",
+                                                "count": 6
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scattering",
+                                                "count": 6
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scoring",
+                                                "count": 6
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "character_tags": [ "Rodman" ]
+            },
+            {
+                "name": "to Nina Nix: Stage 4",
+                "destination": "Nina Nix: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Nina Nix"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scattering",
+                                "count": 3
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scoring",
+                                "count": 3
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scattering",
+                                "count": 3
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scoring",
+                                "count": 3
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Nina Nix" ]
+            },
+            {
+                "name": "to Hayley Bayles: Stage 4",
+                "destination": "Hayley Bayles: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Hayley Bayles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scattering",
+                                "count": 6
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scoring",
+                                "count": 6
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Hayley Bayles" ]
+            },
+            {
+                "name": "to Sam Gambit: Stage 4",
+                "destination": "Sam Gambit: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Sam Gambit"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scattering",
+                                "count": 6
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scoring",
+                                "count": 6
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Sam Gambit" ]
+            },
+            {
+                "name": "to Bones the Dog: Stage 4",
+                "destination": "Bones the Dog: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Bones the Dog"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scattering",
+                                "count": 6
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scoring",
+                                "count": 6
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Bones the Dog" ]
+            },
+            {
+                "name": "to Octacles: Stage 4",
+                "destination": "Octacles: Stage 4",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Octacles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scattering",
+                                "count": 10
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scoring",
+                                "count": 6
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Octacles" ]
             }
-        ],
-        "tags": [ "Octacles" ]
+        ]
     },
     {
-        "name": "Octacles - Stage 5",
-        "exits": [],
-        "tags": [ "Octacles" ]
+        "name": "Stage 5",
+        "exits": [
+            {
+                "name": "to Rodman: Stage 5",
+                "destination": "Rodman: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Rodman"
+                            }
+                        },
+                        {
+                            "rule": "Or",
+                            "children": [
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scattering",
+                                                "count": 8
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Blue Scoring",
+                                                "count": 8
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rule": "And",
+                                    "children": [
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scattering",
+                                                "count": 8
+                                            }
+                                        },
+                                        {
+                                            "rule": "HasGroup",
+                                            "args": {
+                                                "item_name_group": "Red Scoring",
+                                                "count": 8
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "character_tags": [ "Rodman" ]
+            },
+            {
+                "name": "to Nina Nix: Stage 5",
+                "destination": "Nina Nix: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Nina Nix"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scattering",
+                                "count": 4
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Shiny Scoring",
+                                "count": 4
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scattering",
+                                "count": 4
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Void Scoring",
+                                "count": 4
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Nina Nix" ]
+            },
+            {
+                "name": "to Hayley Bayles: Stage 5",
+                "destination": "Hayley Bayles: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Hayley Bayles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scattering",
+                                "count": 8
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Number Scoring",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Hayley Bayles" ]
+            },
+            {
+                "name": "to Sam Gambit: Stage 5",
+                "destination": "Sam Gambit: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Sam Gambit"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scattering",
+                                "count": 7
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Chess Scoring",
+                                "count": 8
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Sam Gambit" ]
+            },
+            {
+                "name": "to Bones the Dog: Stage 5",
+                "destination": "Bones the Dog: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Bones the Dog"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scattering",
+                                "count": 8
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Card Scoring",
+                                "count": 8
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Bones the Dog" ]
+            },
+            {
+                "name": "to Octacles: Stage 5",
+                "destination": "Octacles: Stage 5",
+                "access_rule": {
+                    "rule": "And",
+                    "children": [
+                        {
+                            "rule": "Has",
+                            "args": {
+                                "item_name": "Octacles"
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scattering",
+                                "count": 14
+                            }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "args": {
+                                "item_name_group": "Cursed Scoring",
+                                "count": 8
+                            }
+                        }
+                    ]
+                },
+                "character_tags": [ "Octacles" ]
+            }
+        ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Rodman: Stage {count}",
+        "character_tags": [ "Rodman" ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Nina Nix: Stage {count}",
+        "character_tags": [ "Nina Nix" ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Hayley Bayles: Stage {count}",
+        "character_tags": [ "Hayley Bayles" ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Sam Gambit: Stage {count}",
+        "character_tags": [ "Sam Gambit" ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Bones the Dog: Stage {count}",
+        "character_tags": [ "Bones the Dog" ]
+    },
+
+
+    {
+        "count": 5,
+        "name": "Octacles: Stage {count}",
+        "character_tags": [ "Octacles" ]
     }
 ]

--- a/worlds/cursed_words/data/regions.json
+++ b/worlds/cursed_words/data/regions.json
@@ -174,17 +174,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -223,17 +239,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -278,17 +310,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -327,17 +375,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Sticker Slots",
                                 "count": 4
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args" : {
                                 "item_name_group": "Stamp Slots",
                                 "count": 4
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -374,17 +438,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -436,17 +516,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -483,17 +579,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -536,17 +648,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -584,17 +712,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -661,17 +805,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -723,17 +883,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -791,17 +967,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -839,17 +1031,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -915,17 +1123,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -967,17 +1191,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1001,13 +1241,6 @@
                                     "Fraction Tiles",
                                     "Number Tiles"
                                 ]
-                            }
-                        },
-                        {
-                            "rule": "HasGroup",
-                            "args": {
-                                "item_name_group": "Sticker Slots",
-                                "count": 5
                             }
                         },
                         {
@@ -1042,10 +1275,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Sticker Slots",
+                                "count": 5
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1084,17 +1340,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1159,17 +1431,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1211,17 +1499,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1270,17 +1574,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1319,17 +1639,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1394,17 +1730,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1446,17 +1798,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1505,17 +1873,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1554,17 +1938,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 1
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1641,17 +2041,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 2
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1702,17 +2118,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 3
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }
@@ -1790,17 +2222,33 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
-                            }
+                            },
+                            "filtered_resolution": true
                         }
                     ]
                 }

--- a/worlds/cursed_words/data/regions.json
+++ b/worlds/cursed_words/data/regions.json
@@ -421,6 +421,21 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
@@ -506,6 +521,21 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
@@ -537,6 +567,21 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -583,6 +628,36 @@
                                     "Void Tiles"
                                 ]
                             }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 4
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -633,6 +708,21 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 6
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
@@ -671,6 +761,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 8
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 5
@@ -702,6 +822,21 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -750,6 +885,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 4
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
@@ -784,6 +949,21 @@
                                     "Number Stamps"
                                 ]
                             }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 6
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -832,6 +1012,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 8
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Stamp Slots",
                                 "count": 5
@@ -857,6 +1067,21 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -904,6 +1129,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 4
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
@@ -941,6 +1196,21 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 6
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
@@ -968,6 +1238,36 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 8
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -1002,6 +1302,21 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -1049,6 +1364,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 4
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
@@ -1086,6 +1431,21 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 6
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 3
@@ -1113,6 +1473,36 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 8
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -1147,6 +1537,21 @@
                 "access_rule": {
                     "rule": "And",
                     "children": [
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
                         {
                             "rule": "HasGroup",
                             "args": {
@@ -1206,6 +1611,36 @@
                         },
                         {
                             "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 1
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 4
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
                             "args": {
                                 "item_name_group": "Sticker Slots",
                                 "count": 2
@@ -1249,6 +1684,21 @@
                                     "Number Stamps"
                                 ]
                             }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 6
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",
@@ -1307,6 +1757,36 @@
                                     "Number Tiles"
                                 ]
                             }
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Grid Sizes",
+                                "count": 2
+                            },
+                            "filtered_resolution": true
+                        },
+                        {
+                            "rule": "HasGroup",
+                            "options": [
+                                {
+                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "value": 1,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {
+                                "item_name_group": "Tile Positions",
+                                "count": 8
+                            },
+                            "filtered_resolution": true
                         },
                         {
                             "rule": "HasGroup",

--- a/worlds/cursed_words/data/regions.json
+++ b/worlds/cursed_words/data/regions.json
@@ -176,7 +176,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -191,7 +191,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -241,7 +241,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -256,7 +256,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -312,7 +312,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -327,7 +327,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -377,7 +377,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -392,7 +392,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -440,7 +440,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -455,7 +455,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -503,7 +503,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -518,7 +518,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -533,7 +533,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -581,7 +581,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -596,7 +596,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -635,7 +635,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -650,7 +650,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -665,7 +665,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -699,7 +699,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -714,7 +714,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -729,7 +729,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -777,7 +777,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -792,7 +792,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -807,7 +807,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -822,7 +822,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -870,7 +870,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -885,7 +885,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -900,7 +900,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -939,7 +939,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -954,7 +954,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -969,7 +969,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -984,7 +984,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1018,7 +1018,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1033,7 +1033,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1048,7 +1048,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1095,7 +1095,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1110,7 +1110,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1125,7 +1125,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1140,7 +1140,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1178,7 +1178,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1193,7 +1193,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1208,7 +1208,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1247,7 +1247,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1262,7 +1262,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1277,7 +1277,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1292,7 +1292,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1327,7 +1327,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1342,7 +1342,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1357,7 +1357,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1403,7 +1403,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1418,7 +1418,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1433,7 +1433,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1448,7 +1448,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1486,7 +1486,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1501,7 +1501,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1516,7 +1516,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1546,7 +1546,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1561,7 +1561,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1576,7 +1576,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1591,7 +1591,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1626,7 +1626,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1641,7 +1641,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1656,7 +1656,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1702,7 +1702,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1717,7 +1717,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1732,7 +1732,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1747,7 +1747,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1785,7 +1785,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1800,7 +1800,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1815,7 +1815,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1845,7 +1845,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1860,7 +1860,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1875,7 +1875,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1890,7 +1890,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1925,7 +1925,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1940,7 +1940,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -1955,7 +1955,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2013,7 +2013,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2028,7 +2028,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2043,7 +2043,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2058,7 +2058,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2105,7 +2105,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2120,7 +2120,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2135,7 +2135,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2194,7 +2194,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveGridSize",
+                                    "option": "worlds.cursed_words.Options.ShuffleGridSize",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2209,7 +2209,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveTilePositions",
+                                    "option": "worlds.cursed_words.Options.ShuffleLockedTilePositions",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2224,7 +2224,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }
@@ -2239,7 +2239,7 @@
                             "rule": "HasGroup",
                             "options": [
                                 {
-                                    "option": "worlds.cursed_words.Options.ProgressiveInventorySlots",
+                                    "option": "worlds.cursed_words.Options.ShuffleInventorySlots",
                                     "value": 1,
                                     "operator": "eq"
                                 }

--- a/worlds/stacklands/Rules.py
+++ b/worlds/stacklands/Rules.py
@@ -1510,7 +1510,7 @@ def set_rules(world: MultiWorld, player: int):
       
       set_rule(world.get_location("Build a University", player),
                lambda state: # Phase Two
-                  state.sl_has_all_ideas(["Brick", "University"]))
+                  state.sl_has_all_ideas(["Brick", "University"], player))
 
       set_rule(world.get_location("Build a Warehouse", player),
                lambda state:  # Phase Three


### PR DESCRIPTION
Provides the following:
- Complete re-work of Sticker / Stamp items and are now each their own individual items
  - Not all stickers and stamps present, but a good majority
- Regions and access rules re-worked as a result of the above
- 'Scaling' locations such as Word Score and Total Earned have been expanded
- YAML option added to toggle shuffling Sticker / Stamp slots into the item pool
- YAML option added to toggle Boss-sanity 
